### PR TITLE
Update docs with install printout to match updated CLI

### DIFF
--- a/content/docs/getting-started/fluvio-local-faq.md
+++ b/content/docs/getting-started/fluvio-local-faq.md
@@ -68,7 +68,7 @@ If you see an error like the one below, it's likely that you forgot to run
 the install command with the `--sys` option first.
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
+$ fluvio cluster install
 Error: 
    0: Fluvio cluster error
    1: An unknown error occurred: Fluvio system chart is not installed, please install fluvio-sys first
@@ -82,7 +82,7 @@ Run with RUST_BACKTRACE=full to include source snippets.
 (note the `--sys` flag at the end)
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest --sys
+$ fluvio cluster install
 ```
 
 ### `fluvio cluster install`: Cluster in kube context cannot use IP address
@@ -91,7 +91,7 @@ If you see an error like the one below, something went wrong when Fluvio tried t
 integrate with Minikube.
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
+$ fluvio cluster install
 Error: 
    0: Fluvio cluster error
    1: An unknown error occurred: Cluster in kube context cannot use IP address, please use minikube context: 172.17.0.3
@@ -114,7 +114,7 @@ $ fluvio cluster set-minikube-context
 Sometimes when running the install command, you might run into a loop like this:
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
+$ fluvio cluster install
 "fluvio" already exists with the same configuration, skipping
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
@@ -161,7 +161,7 @@ $ sudo minikube tunnel
 Sometimes when running the install command, you might run into a loop like this:
 
 ```bash
-fluvio@fluvio:~/fluvio$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
+fluvio@fluvio:~/fluvio$ fluvio cluster install
 "fluvio" already exists with the same configuration, skipping
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
@@ -222,7 +222,7 @@ persistentvolumeclaim "data-flv-spg-main-0" deleted
 Then, when you go to re-install it, a successful install will look like this:
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
+$ fluvio cluster install
 "fluvio" already exists with the same configuration, skipping
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
@@ -360,7 +360,7 @@ to run the uninstaller to reset to a fresh state. You need to do that if you enc
 the following error:
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest --sys
+$ fluvio cluster install
 Error: repository name (fluvio) already exists, please specify a different name
 Exited with status code: 1
 The application panicked (crashed).

--- a/content/docs/getting-started/fluvio-local.md
+++ b/content/docs/getting-started/fluvio-local.md
@@ -164,46 +164,29 @@ add an entry for minikube to your `/etc/hosts` file.
 $ fluvio cluster set-minikube-context
 ```
 
-Kubernetes apps often come in two halves - a so-called "system" chart, and an "app" chart.
-We need to install the system chart first. To do that, run the following:
+Once we've got that set up, we can run our main installation command:
 
 ```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest --sys
-"fluvio" has been added to your repositories
+$ fluvio cluster install
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
 Update Complete. ⎈Happy Helming!⎈
 NAME: fluvio-sys
-LAST DEPLOYED: Fri Oct  2 09:30:44 2020
+LAST DEPLOYED: Sun Oct  4 02:16:16 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
-fluvio sys chart has been installed
-```
-
-Now, we can install the "app" chart:
-
-```bash
-$ fluvio cluster install --chart-version=0.6.0-latest --image-version=latest
 "fluvio" already exists with the same configuration, skipping
 Hang tight while we grab the latest from your chart repositories...
 ...Successfully got an update from the "fluvio" chart repository
 Update Complete. ⎈Happy Helming!⎈
 NAME: fluvio
-LAST DEPLOYED: Fri Oct  2 10:20:52 2020
+LAST DEPLOYED: Sun Oct  4 02:16:18 2020
 NAMESPACE: default
 STATUS: deployed
 REVISION: 1
 TEST SUITE: None
-waiting for sc service up come up: 0
-waiting for sc service up come up: 1
-0 of 1 spu ready
-0 of 1 spu ready
-0 of 1 spu ready
-0 of 1 spu ready
-0 of 1 spu ready
-0 of 1 spu ready
 waiting for spu to be provisioned
 1 spus provisioned
 ```


### PR DESCRIPTION
As of infinyon/fluvio#358, users no longer need to do two install commands (one with `--sys` and one without). As of some earlier point in time, they also do not need to manually pass `--chart-version` and `--image-version`. I've updated the documentation to reflect these changes.