### PR TITLE
Add new CLI installation instructions to docs

### DIFF
--- a/assets/styles/_highlight.scss
+++ b/assets/styles/_highlight.scss
@@ -34,7 +34,7 @@
 /* LiteralStringInterpol */ .chroma .si { color: #e6db74 }
 /* LiteralStringOther */ .chroma .sx { color: #e6db74 }
 /* LiteralStringRegex */ .chroma .sr { color: #e6db74 }
-/* LiteralStringSingle */ .chroma .s1 { color: #e6db74 }
+/* LiteralStringSingle */ .chroma .s1 { color: #ffffff }
 /* LiteralStringSymbol */ .chroma .ss { color: #e6db74 }
 /* LiteralNumber */ .chroma .m { color: #ae81ff }
 /* LiteralNumberBin */ .chroma .mb { color: #ae81ff }

--- a/content/docs/getting-started/fluvio-cli.md
+++ b/content/docs/getting-started/fluvio-cli.md
@@ -20,7 +20,7 @@ $ curl -fsS https://packages.fluvio.io/v1/install.sh | bash
 
 If everything works successfully, you should see output similar to this:
 
-```
+```bash
 fluvio: ⏳ Downloading Fluvio 0.6.0-alpha.5 for x86_64-apple-darwin...
 fluvio: ⬇️ Downloaded Fluvio, installing...
 fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio

--- a/content/docs/getting-started/fluvio-cli.md
+++ b/content/docs/getting-started/fluvio-cli.md
@@ -10,35 +10,64 @@ up, managing, and interacting with Fluvio.
 
 -> Please note that we currently only support Linux and MacOS
 
-#### Download
+#### Download and Install
 
-Download the Fluvio CLI from our [github releases] page
-
-[github releases]: https://github.com/infinyon/fluvio/releases
-
-You'll want to rename the binary to `fluvio` and mark it as executable. For the
-following command, make sure to use the filename of the release you downloaded.
+Downloading and installing Fluvio is as simple as running the following command!
 
 ```bash
-$ mv fluvio-v0.6.0-alpha.2-x86_64-apple-darwin fluvio
-$ chmod +x ./fluvio
+$ curl -fsS https://packages.fluvio.io/v1/install.sh | bash
 ```
 
-Then, install the CLI by moving it into a bin folder in your PATH, like this
+If everything works successfully, you should see output similar to this:
+
+```
+fluvio: ⏳ Downloading Fluvio 0.6.0-alpha.5 for x86_64-apple-darwin...
+fluvio: ⬇️ Downloaded Fluvio, installing...
+fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio
+fluvio: ☁️ Installing Fluvio Cloud...
+fluvio: 🎣 Fetching latest version for package: fluvio/fluvio-cloud...
+fluvio: ⏳ Downloading package with latest version: fluvio/fluvio-cloud:0.1.0...
+fluvio: 🔑 Downloaded and verified package file
+fluvio: ✅ Successfully installed ~/.fluvio/bin/fluvio-cloud
+fluvio: 🎉 Install complete!
+fluvio: 💡 You'll need to add '~/.fluvio/bin/' to your PATH variable
+fluvio:     You can run the following to set your PATH on shell startup:
+fluvio:       For bash: echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.bashrc
+fluvio:       For zsh : echo 'export PATH="${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
+fluvio:
+fluvio:     To use Fluvio you'll need to restart your shell or run the following:
+fluvio:       export PATH="${HOME}/.fluvio/bin:${PATH}"
+```
+
+Notice the steps it lists at the bottom. In order to use the `fluvio` command,
+you'll need to make sure that `~/.fluvio/bin/` (the directory where it was installed to)
+is part of your system's PATH - the list of directories where your shell looks for
+executables. Once you've followed those instructions, make sure you can run the following
+commands:
 
 ```bash
-$ sudo mv ./fluvio /usr/local/bin/
-```
-
-Now you can run the `fluvio version` command to make sure it worked. Keep in mind
-that you may see different versions than what's shown here.
-
-```shell
 $ fluvio version
-Fluvio version : 0.6.0
-Git Commit     : 3ff1ee52a31f51c2a3dc7d8fe3996d694fdd585d
+Fluvio version : 0.6.0-alpha.5
+Git Commit     : 42b975df60ca230732b123dbee74b6ca92195f7a
 OS Details     : Darwin 19.6.0 x86_64
-Rustc Version  : 1.46.0 (04488af 2020-08-24)
+Rustc Version  : 1.47.0 (18bf6b4 2020-10-07)
+```
+
+```bash
+$ fluvio cloud
+fluvio-cloud 0.1.0
+
+USAGE:
+    fluvio-cloud <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help      Prints this message or the help of the given subcommand(s)
+    login     Log into Fluvio Cloud with a username and password
+    logout    Log out of a Fluvio Cloud account
 ```
 
 #### Next Steps

--- a/content/docs/getting-started/fluvio-cloud.md
+++ b/content/docs/getting-started/fluvio-cloud.md
@@ -45,11 +45,11 @@ You should get a confirmation that your account is ready to use
 
 At this point, we can log in via the Fluvio CLI and start sending and receiving
 messages to your Fluvio cluster. To log in with the CLI, you'll need to run the
-`fluvio profile cloud sync` command, then type in your email and password when
+`fluvio cloud login` command, then type in your email and password when
 prompted.
 
 ```bash
-$ fluvio profile sync cloud --remote=https://cloud.fluvio.io
+$ fluvio cloud login
 Fluvio Cloud email: batman@justiceleague.com
 Password:
 ```


### PR DESCRIPTION
Now that we have the one-liner install script, I wanted to update the CLI docs to reflect it.