### PR TITLE
Fix wording on fluvio-local prerequisites

### DIFF
--- a/content/docs/getting-started/fluvio-local.md
+++ b/content/docs/getting-started/fluvio-local.md
@@ -16,8 +16,8 @@ called Minikube which is meant for testing out Kubernetes apps locally.
 ## Prerequisites
 
 Before getting started, make sure you have the [Fluvio CLI] installed, as
-we'll be using that to connect to your account and download your connection
-profile.
+we'll be using that to interact with your cluster and make sure everything
+is working as expected.
 
 [Fluvio CLI]: ../fluvio-cli
 


### PR DESCRIPTION
There was confusion before about whether the Fluvio CLI was needed for a local installation because the wording on the Prerequisite section seemed to indicate that the CLI was for Fluvio Cloud only. This updates the wording to make it more clear.