### PR TITLE
Add minimum version numbers and update instructions to tutorials

### DIFF
--- a/content/tutorials/node/hello-world.md
+++ b/content/tutorials/node/hello-world.md
@@ -11,9 +11,14 @@ In this tutorial, you will learn how to create a topic, build a producer/consume
 Before starting on this tutorial, you'll need to have completed the following
 
 - Install [Node.js](#check-nodejs) (**v12.11.0** or above) 
-- Have the Fluvio CLI installed and have access to a Fluvio cluster. See our [getting started] guide.
+- Have the Fluvio CLI (version  `0.6.0-rc.5` or greater) installed <sup>[1]</sup>
+- Have access to a Fluvio cluster.
+
+See our [getting started] guide for more details on getting set up.
 
 [getting started]: /docs/getting-started
+
+-> [1]: If you need to, you can update the Fluvio CLI by using `fluvio update`.
 
 ### Create a Topic using the Fluvio CLI
 

--- a/content/tutorials/rust/hello-world.md
+++ b/content/tutorials/rust/hello-world.md
@@ -16,10 +16,15 @@ back.
 Before starting on this tutorial, you'll need to have completed the following
 
 - Install the [Rust programming language]
-- Have the Fluvio CLI installed and have access to a Fluvio cluster. See our [getting started] guide.
+- Have the Fluvio CLI (version  `0.6.0-rc.5` or greater) installed <sup>[1]</sup>
+- Have access to a Fluvio cluster.
+  
+See our [getting started] guide for more details on getting set up.
 
 [Rust programming language]: https://rustup.rs
 [getting started]: /docs/getting-started
+
+-> [1]: If you need to, you can update the Fluvio CLI by using `fluvio update`.
 
 ### Create a Topic using the Fluvio CLI
 
@@ -60,7 +65,7 @@ authors = ["Your name <your_email@example.com>"]
 edition = "2018"
 
 [dependencies]
-fluvio = "0.1.0"
+fluvio = "0.3.4"
 async-std = "1.0.0"
 ```
 


### PR DESCRIPTION
Our tutorials do not work with certain outdated Fluvio versions. I have added minimum Fluvio version numbers to the tutorials to prevent future users from encountering the same trouble that has been seen before https://github.com/infinyon/fluvio/issues/660#issuecomment-758025652