### PR TITLE
Move release notes into fluvio-cloud

### DIFF
--- a/content/docs/fluvio-cloud/release-notes.md
+++ b/content/docs/fluvio-cloud/release-notes.md
@@ -1,8 +1,8 @@
 ---
 title: Fluvio Cloud Release Notes
-menu: Fluvio Cloud Release Notes
+menu: Release Notes
 toc: true
-weight: 500
+weight: 200
 ---
 
 This page contains the latest release notes for updates to [Fluvio Cloud].


### PR DESCRIPTION
This moves the `release-notes` page under the Fluvio Cloud section

<img width="926" alt="image" src="https://user-images.githubusercontent.com/4210949/105220363-9e23dc80-5b25-11eb-8d1b-721b2b641440.png">
