### PR TITLE
Cloud announcment rewrite

### DIFF
--- a/content/blog/_posts/2021-02-fluvio-cloud.md
+++ b/content/blog/_posts/2021-02-fluvio-cloud.md
@@ -33,10 +33,10 @@ started right away.  Getting started is as simple as creating an account and
 installing the [Fluvio CLI], our all-in-one tool for working with Fluvio.
 
 One of the cool things about Fluvio is that we leverage [Rust's FFI] allowing
-us to reuse core compenents in our non-rust client libraries. This is how we
-were able to build a [node-js client] without too much work.
+us to reuse core compenents in our non-rust client libraries.  We used this
+construct to build [node-js client] as shown below.
 
-There are tons of reasons why Fluvio is awesome but this is a post about using
+There are many reasons why Fluvio is awesome but this is a post about using
 Fluvio Cloud. :)
 
 [Rust's FFI]: https://doc.rust-lang.org/nomicon/ffi.html#calling-foreign-functions
@@ -45,9 +45,8 @@ Fluvio Cloud. :)
 
 # Using The Fluvio Cloud Platform
 
-We've written plenty of [Fluvio tutorials](/tutorials) but we'd like to show
-how Fluvio cloud acts the same as if you were using it locally or if you host
-it yourself.
+There are several [blog posts](/blog) and [tutorials](/tutorials) that show the power of Fluvio
+when utilized for powering real-time services.
 
 ## Setup
 Setting up the cloud is very straight forward as mentioned in the introduction
@@ -106,12 +105,14 @@ $ fluvio consume hello-fluvio-cloud
 Hello fluvio cloud!
 ```
 
-Similar to using the commandline, using the [rust
+### Produce/Consume using Rust/Node.JS
+
+You can also use produce and consume programmatically, using our [rust
 client](https://crates.io/crates/fluvio) and [nodejs
 client](https://www.npmjs.com/package/@fluvio/client) requires no addional
 steps to use Fluvio Cloud.
 
-We'll leave out the project setup steps but if you have:
+See our [tutorials](/tutorials) for the entire guide but to use rust or nodejs you need:
 
 ```javascript
 const fluvio = await Fluvio.connect();
@@ -130,11 +131,43 @@ while let Some(Ok(record)) = stream.next().await {
 }
 ```
 
-And run the rust version in one terminal and the node version in the other
+And run the rust version in one terminal and the node version in another
 terminal, the rust consumer will print:
 ```
 Got Record: Hello Fluvio Cloud! 🎉
 ```
+
+# Fluvio Platform Highlights
+* **Declarative Management**: Fluvio allows operators to declare desired state
+and the system will do the rest. No resource available, no worries, the objects
+are shown `in progress` until the resource constraints are resolved.
+
+* **Low Latency**: Fluvio takes advantage of Rust’s async runtime and all
+available cores. It also interacts directly with hardware I/O to achieve
+predictable ultra-low latency.
+
+* **Low Memory Footprint**: Fluvio is highly optimized machine code and it does
+not require an intermediary virtual machine. Fluvio can run anywhere from
+Raspberry Pi to  multi-core systems.
+
+* **Built-in Retention**: Fluvio uses long-lived immutable storage to persist
+data streams. Each data stream is copied to multiple servers and retained for
+hours or years.
+
+* **Guaranteed Message Ordering**: Fluvio guarantees partition-level message
+ordering. Messages are stored and forwarded to consumers in the order they are
+received from the producers.
+
+* **Cloud Native by Design**: Fluvio is designed to work natively with
+Kubernetes. It uses Helm charts for installation, CRDs for provisioning, and
+Operators to interact with the KV store.
+
+* **Developer Friendly**: Fluvio offers native language bindings in many modern
+programming languages such as Rust and Node (Python, Java, and Swift will be
+        available in future releases).
+
+* **Powerful CLI:** Fluvio CLI can manage all your clusters whether they are
+installed locally, in your data center, or in a public cloud.
 
 
 # Summary

--- a/content/blog/_posts/2021-02-fluvio-cloud.md
+++ b/content/blog/_posts/2021-02-fluvio-cloud.md
@@ -27,20 +27,19 @@ infrastructure is a painful, expensive, and error-prone endeavor. This is why
 we built Fluvio - the open-source, high-performance distributed data streaming
 platform for real-time apps that's written in Rust.
 
-Building a streaming tool is just have just half the battle so we build Fluvio
+Building a streaming tool is just have just half the battle so we built Fluvio
 Cloud which provisions and manages your Fluvio cluster for you, letting you get
 started right away.  Getting started is as simple as creating an account and
 installing the [Fluvio CLI], our all-in-one tool for working with Fluvio.
 
-One of the cool things about Fluvio is that we leverage [Rust's FFI] so that
-our code can be called from any language that supports the FFI which is [very
-few exceptions]. This is how we were able to build a [node-js client] without
-too much work.
+One of the cool things about Fluvio is that we leverage [Rust's FFI] allowing
+us to reuse core compenents in our non-rust client libraries. This is how we
+were able to build a [node-js client] without too much work.
 
-There are tons of reasons why Fluvio is awesome but this is a post about Fluvio Cloud. :)
+There are tons of reasons why Fluvio is awesome but this is a post about using
+Fluvio Cloud. :)
 
 [Rust's FFI]: https://doc.rust-lang.org/nomicon/ffi.html#calling-foreign-functions
-[very few exceptions]: https://softwareengineering.stackexchange.com/questions/21300/what-imperative-programming-languages-do-not-support-recursion
 [Fluvio CLI]: /docs/getting-started/
 [node-js client]: https://github.com/infinyon/fluvio-client-node
 
@@ -58,8 +57,7 @@ you. Then to make use of it, just do
 ```bash
 fluvio cloud login
 ```
-
-and this will propt you for the credentials you used to sign up in the web
+This will propt you for the credentials you used to sign up in the web
 form. It will then store this as a profile setting. You can see this setting by
 doing:
 ```bash
@@ -73,6 +71,7 @@ fluvio profile switch cloud
 ```
 
 ## Producing and Consuming a datastream
+
 On a fresh Fluvio instance, you'll need to create some topics:
 ```bash
 fluvio topic create hello-fluvio-cloud
@@ -85,17 +84,17 @@ In one terminal do:
 fluvio consume hello-fluvio-cloud
 ```
 
-and in another do:
+and in another terminal do:
 
 ```bash
 fluvio produce hello-fluvio-cloud
 ```
 
 The produce command listens to `stdin` and sends it to fluvio cloud on the
-specified topic. In our case, `hello-fluvio-cloud`. Type into the `produce`
-terminal.
+specified topic. In our case, the topic is `hello-fluvio-cloud`. Now, type
+`Hello fluvio cloud!` (or whatever you'd like) into the producer terminal.
 
-Your two terminals should look like:
+Your two terminals should now look like:
 ```bash
 $ fluvio produce hello-fluvio-cloud
 Hello fluvio cloud!
@@ -140,16 +139,11 @@ Got Record: Hello Fluvio Cloud! 🎉
 
 # Summary
 
-Setting up a real-time data streaming app shouldn't be a ton of work and
-hopefully this post shows just how simple yet powerful our platform is and will
-become.
+Setting up a real-time data streaming app should be easy and painless. Hopefully this
+post shows you just how simple yet powerful our platform is.
 
-Join the conversation on [Discord](https://discordapp.com/invite/bBG2dTz), follow [the project on github](https://github.com/infinyon/fluvio/watchers) or open an [issue](https://github.com/infinyon/fluvio/issues) if you find a bug or have a feature request.
-
-[getting started guide]: https://www.fluvio.io/docs/getting-started/
-
-* [Discord](https://discordapp.com/invite/bBG2dTz)
-
-[free Fluvio Cloud account]: https://cloud.fluvio.io/signup
-[getting started guide]: https://www.fluvio.io/docs/getting-started/
-
+Don't forget to join the conversation on
+[Discord](https://discordapp.com/invite/bBG2dTz), follow [the project on
+github](https://github.com/infinyon/fluvio/watchers) or open an
+[issue](https://github.com/infinyon/fluvio/issues) if you find a bug or have a
+feature request.

--- a/content/blog/_posts/2021-02-fluvio-cloud.md
+++ b/content/blog/_posts/2021-02-fluvio-cloud.md
@@ -21,13 +21,13 @@ Fluvio Cloud is now in alpha, and you can create a free account using the link b
 
 # About Fluvio
 
-Our business research has show that modern businesses require real-time
+Our business research has shown that modern businesses require real-time
 collaboration, analysis, and adaptation. Yet, building real-time
 infrastructure is a painful, expensive, and error-prone endeavor. This is why
 we built Fluvio - the open-source, high-performance distributed data streaming
 platform for real-time apps that's written in Rust.
 
-Building a streaming tool is just have just half the battle so we built Fluvio
+Building a streaming tool is just half the battle so we built Fluvio
 Cloud which provisions and manages your Fluvio cluster for you, letting you get
 started right away.  Getting started is as simple as creating an account and
 installing the [Fluvio CLI], our all-in-one tool for working with Fluvio.

--- a/content/blog/_posts/2021-02-fluvio-cloud.md
+++ b/content/blog/_posts/2021-02-fluvio-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Announcing Fluvio Cloud Platform
-author: 
+author:
     name: "The Fluvio Team"
 description: Today we are pleased to announce Fluvio Cloud, the easiest way to get started with Fluvio.
 metadata: NEWS
@@ -10,158 +10,146 @@ url: /blog/2021/02/announcing-fluvio-cloud-platform
 img: blog/images/fluvio-cloud/social/cloud.jpg
 tile: blog/images/fluvio-cloud/social/cloud-tile.svg
 twitter-card: summary_large_image
-hidden: true
+hidden: false
 ---
 
 
-Today we are pleased to announce Fluvio Cloud, the fastest and easiest way to get started using Fluvio.
+Today we are pleased to announce The Fluvio Cloud Platform, the fastest and easiest way to get started using Fluvio.
 Fluvio Cloud is now in alpha, and you can create a free account using the link below:
 
 <center><a class="btn btn-primary" href="https://cloud.fluvio.io/signup" target="_blank" role="button">Sign Up for Fluvio Cloud</a></center>
 
-Fluvio is an open-source, high-performance distributed data streaming platform for real-time apps, written
-in Rust. Fluvio Cloud provisions and manages your Fluvio cluster for you, letting you get started right away.
-Getting started is as simple as creating an account and installing the [Fluvio CLI], our all-in-one
-tool for working with Fluvio.
-
-[Fluvio CLI]: /docs/getting-started/
-
 # About Fluvio
 
-We believe that modern business requires real-time collaboration, analysis, and adaptation.
-Yet, building real-time infrastructure is a painful, expensive, and error-prone endeavor.
-One of our goals with Fluvio is to make it easy to build real-time applications by providing a
-real-time application development platform. Fluvio is built on three core principles that guide
-us in achieving this goal:
+Our business research has show that modern businesses require real-time
+collaboration, analysis, and adaptation. Yet, building real-time
+infrastructure is a painful, expensive, and error-prone endeavor. This is why
+we built Fluvio - the open-source, high-performance distributed data streaming
+platform for real-time apps that's written in Rust.
 
-1) **Data is modeled as streams of events**, and streams should deliver data as fast as possible
-2) **APIs and tools should be easy to use**, so that anybody can build real-time applications
+Building a streaming tool is just have just half the battle so we build Fluvio
+Cloud which provisions and manages your Fluvio cluster for you, letting you get
+started right away.  Getting started is as simple as creating an account and
+installing the [Fluvio CLI], our all-in-one tool for working with Fluvio.
 
-## Data Streams
+One of the cool things about Fluvio is that we leverage [Rust's FFI] so that
+our code can be called from any language that supports the FFI which is [very
+few exceptions]. This is how we were able to build a [node-js client] without
+too much work.
 
-Our first principle is to use streams as our fundamental model of data.
-Data streams represent a continuous flow of messages that describe events that have occurred.
-The unit of a stream is a single message (sometimes called a record), and messages
-can be as small or as large as needed to fit the needs of the application.
-Fluvio's data streams are implemented as persistent logs, meaning that all messages get written
-to disk and have a strict ordering, indicated by each message's offset in the stream, which never changes.
-Our data streaming engine has been written with a focus on four key properties that
-make it ideal for building production-ready real-time applications: speed, scale, retention, and resiliency.
+There are tons of reasons why Fluvio is awesome but this is a post about Fluvio Cloud. :)
 
-### Speed
+[Rust's FFI]: https://doc.rust-lang.org/nomicon/ffi.html#calling-foreign-functions
+[very few exceptions]: https://softwareengineering.stackexchange.com/questions/21300/what-imperative-programming-languages-do-not-support-recursion
+[Fluvio CLI]: /docs/getting-started/
+[node-js client]: https://github.com/infinyon/fluvio-client-node
 
-One of the primary goals of a streaming platform is to deliver messages from
-point A to point B as quickly as possible.
-Fluvio's streaming architecture is designed to maximize performance, and has a key
-advantage over other streaming platforms: it's written from the ground-up in Rust.
-Rust is a modern systems programming language that produces executables that
-perform competitively with C and C++ programs, but prevents many types of errors
-such as memory and concurrency errors via compile-time checks.
-Rust also features automatic memory management, but does not have a garbage collector,
-meaning that it doesn't suffer from the [stop-the-world] problem that JVM streaming
-platforms experience. This means that Fluvio will be able to provide lower-latency
-message delivery at a higher confidence interval.
+# Using The Fluvio Cloud Platform
 
-[stop-the-world]: https://en.wikipedia.org/wiki/Tracing_garbage_collection#Stop-the-world_vs._incremental_vs._concurrent
+We've written plenty of [Fluvio tutorials](/tutorials) but we'd like to show
+how Fluvio cloud acts the same as if you were using it locally or if you host
+it yourself.
 
-### Scalability
+## Setup
+Setting up the cloud is very straight forward as mentioned in the introduction
+but we'll reiterate those steps anyway. Once you've verified your account (link
+        in the email), a fluvio instance will be automatically provisioned for
+you. Then to make use of it, just do
+```bash
+fluvio cloud login
+```
 
-Scalability is the ability of a system to gracefully handle massive
-volumes of data. Fluvio's data streaming architecture was designed
-with this in mind from the start. In Fluvio, streaming is performed
-by Streaming Processing Units (or SPUs), which are deployed
-cooperatively in a Kubernetes cluster. Naturally, each SPU has a
-particular capacity of storage, processing power, and bandwidth, so
-as the system demands increase, Fluvio scales horizontally by simply
-adding more SPUs to the mix. This process is automatically coordinated
-by the Streaming Controllers (SCs), giving the system an elastic
-behavior which can cost-effectively handle spikes in traffic without
-needing a long-term commitment to peak capacity.
+and this will propt you for the credentials you used to sign up in the web
+form. It will then store this as a profile setting. You can see this setting by
+doing:
+```bash
+fluvio profile view
+```
 
-On a more micro level, Fluvio achieves high scalability by leveraging
-Rust's asynchronous programming model. This makes it easy to write code
-that multitasks, efficiently performing work that is ready to be done
-without wasting time on blocking work such as IO. This means that all
-of Fluvio's components are fully utilizing the available hardware,
-getting more done at a lower cost.
+If you've already got a local instance of fluvio running, you can easily switch
+the instance the client is using by doing:
+```bash
+fluvio profile switch cloud
+```
 
-### Retention
+## Producing and Consuming a datastream
+On a fresh Fluvio instance, you'll need to create some topics:
+```bash
+fluvio topic create hello-fluvio-cloud
+```
 
-For many applications, it can be very beneficial to retain a long-term history
-of the events that have occurred. In traditional databases, the only thing that
-is preserved is the sum of all past events - the "current" state. In contrast,
-Fluvio's data streams are implemented as immutable logs, meaning that we can
-not only view the current state, but also the entire state of the system at any
-point in time. This is incredibly powerful, as it grants us capabilities that
-otherwise wouldn't be possible. For example, we can test new product features
-using historical data (think ML use-cases), generate audit reports, perform
-retrospective analysis, and even rebuild in-memory databases.
+Getting data in and out of the cloud is just as easy as all our other tutorials:
 
-### Availability
+In one terminal do:
+```bash
+fluvio consume hello-fluvio-cloud
+```
 
-Finally, a characteristic that we always need in production systems is high
-availability. Fluvio employs a number of strategies to ensure that it is
-resilient to many different types of failures, keeping data readily available
-at all times. Primarily, Fluvio data streams natively support replication, meaning
-that data is guaranteed to have live copies on at least `n` different nodes,
-where `n` is the configured "replication factor". This means that even in the
-case of spurious node failures, Fluvio can always provide failover so that
-reads and writes are redirected to the available nodes. Additionally, the
-cluster can heal itself: if a failed node comes back online, it will resynchronize
-itself and continue running; or, if the node fails to come back online, it
-simply gets replaced, and a new node takes its place. For additional disaster
-protection, Fluvio can provide replication between availability zones, meaning
-that even a complete data center outage will not compromise the availability of
-Fluvio data streams.
+and in another do:
 
-## Ease of Use
+```bash
+fluvio produce hello-fluvio-cloud
+```
 
-Our last principle is Ease of Use. We believe that by making Fluvio easy to use,
-we will create opportunities for more people and more projects to get into the
-world of real-time applications. The biggest way that we do this is by crafting
-tools and APIs that are pleasant to use and which hide the complexity of the
-underlying distributed system. Since Fluvio is open-source, we also welcome
-feedback and ideas from the community in order to help us build the best user
-experience possible.
+The produce command listens to `stdin` and sends it to fluvio cloud on the
+specified topic. In our case, `hello-fluvio-cloud`. Type into the `produce`
+terminal.
 
-### Powerful CLI
+Your two terminals should look like:
+```bash
+$ fluvio produce hello-fluvio-cloud
+Hello fluvio cloud!
+Ok!
+```
 
-Fluvio's two main user interfaces are the Fluvio CLI and the programmatic client libraries.
-The Fluvio CLI is an all-in-one tool for managing and interacting with your Fluvio
-clusters, and lets you play with data and inspect the state of the system. From the
-CLI, you can view your topics and partitions, produce and consume data, and even
-stand up and tear down whole clusters. The CLI natively supports multiple profiles,
-so you can interact with multiple clusters just by switching the active profile. This can
-be useful when working with multiple environments such as dev/test/prod or local/cloud.
+```bash
+$ fluvio consume hello-fluvio-cloud
+Hello fluvio cloud!
+```
 
-### Language Native APIs
+Similar to using the commandline, using the [rust
+client](https://crates.io/crates/fluvio) and [nodejs
+client](https://www.npmjs.com/package/@fluvio/client) requires no addional
+steps to use Fluvio Cloud.
 
-Our programmatic APIs are built to leverage the idioms of each language. Our Rust client
-offers a fully async interface and makes use of the ecosystem's `Future` and `Stream` traits
-to integrate smoothly with other async streaming code. In Node, we make use of `AsyncIterator`
-in order to enable `for await` syntax for iterating over records. We will be adding more
-language clients in the future, and we're always open to feedback. Feel free to join our
-[Discord chat] and let us know what language support you'd like to see.
+We'll leave out the project setup steps but if you have:
 
-### Declarative Management
+```javascript
+const fluvio = await Fluvio.connect();
+const producer = await fluvio.topicProducer('hello-fluvio-cloud');
+await producer.sendRecord("Hello Fluvio Cloud! 🎉");
+```
 
-Our client APIs make Fluvio a great choice for developers, but how OPs friendly is it?
-Fluvio is built to run natively on Kubernetes, employing operator patterns in order to
-self-govern cluster components and keep the system healthy. Fluvio is configured declaratively,
-meaning that human operators simply declare the target state of the system, and the cluster
-handles the rest. This also includes continuous state reconciliation - if a node goes down
-or if the state of the system diverges from the target state, Fluvio will automatically take
-action to return to the target state, meaning fewer midnight pager-duty alerts.
+and
+```rust
+let consumer = fluvio::consumer("hello-fluvio-cloud", 0).await?;
+let mut stream = consumer.stream(Offset::beginning()).await?;
 
-# Conclusion
+while let Some(Ok(record)) = stream.next().await {
+    let string = String::from_utf8_lossy(&record.as_ref());
+    println!("Got record: {}", string);
+}
+```
 
-Thanks for reading to the end! We hope that you're as excited as we are for
-the future of real-time applications. If you liked the blog, feel free to
-share it around or to come let us know your thoughts! We have a community
-[Discord chat] if you'd like to pop in. If you want to get started building
-with Fluvio, the easiest way to begin is with a [free Fluvio Cloud account]
-and to follow our [getting started guide]!.
+And run the rust version in one terminal and the node version in the other
+terminal, the rust consumer will print:
+```
+Got Record: Hello Fluvio Cloud! 🎉
+```
 
-[Discord chat]: https://discordapp.com/invite/bBG2dTz
+
+# Summary
+
+Setting up a real-time data streaming app shouldn't be a ton of work and
+hopefully this post shows just how simple yet powerful our platform is and will
+become.
+
+Join the conversation on [Discord](https://discordapp.com/invite/bBG2dTz), follow [the project on github](https://github.com/infinyon/fluvio/watchers) or open an [issue](https://github.com/infinyon/fluvio/issues) if you find a bug or have a feature request.
+
+[getting started guide]: https://www.fluvio.io/docs/getting-started/
+
+* [Discord](https://discordapp.com/invite/bBG2dTz)
+
 [free Fluvio Cloud account]: https://cloud.fluvio.io/signup
 [getting started guide]: https://www.fluvio.io/docs/getting-started/
+


### PR DESCRIPTION
I think I spent more time thinking about what we should write than actually writing. I settled on a simple tutorial that's basically the same thing as running fluvio. The point behind doing it here is that it highlights the core value proposition of fluvio cloud - Building a streaming data app without the hassle of devops.

Our first version of this just had too much "About Fluvio" and not enough "about fluvio cloud". We don't have enough features yet to have something like [the EKS AWS announcment](https://aws.amazon.com/blogs/aws/amazon-eks-now-generally-available/) but we will eventually. So, in our case, it's a bit more terminal stuff than graphics of the website.

It's not quite the same but this is what the post looks like [rendered](https://github.com/simlay/fluvio-website/blob/cloud-announcment-rewrite/content/blog/_posts/2021-02-fluvio-cloud.md).