### PR TITLE
getting started docs

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,3 +4,9 @@ menu: Overview
 section: Docs
 description: tiled view with a top banner
 ---
+
+Welcome! Thanks for your interest in Fluvio, the high-performance, low-latency streaming platform for real-time applications. 
+
+In this guide, we're going to walk through the setup process for getting started with Fluvio.
+
+Start with installing the Fluvio CLI, then later we'll show you how to get access to a Fluvio cluster via CLI with your local Fluvio instance or with Fluvio Cloud.

--- a/content/docs/get-started/before-starting-server.md
+++ b/content/docs/get-started/before-starting-server.md
@@ -1,0 +1,142 @@
+---
+title: Before starting server 
+menu: Before starting server
+weight: 20
+---
+
+## Prerequisites
+
+Before getting started, make sure you have the [Fluvio CLI] installed, as
+we'll be using that to interact with your cluster and make sure everything
+is working as expected.
+
+[Fluvio CLI]: {{< ref "/docs/get-started/cli.md" >}}
+
+## Required Packages
+
+1) [Install Docker](#installing-docker)
+2) [Install Minikube](#installing-minikube)
+3) [Install Kubectl](#installing-kubectl)
+4) [Install Helm](#installing-helm)
+
+If you already have `docker`, `kubectl`, `helm`, and `minikube` set up, continue onto [Start Server].
+
+[Start Server]: {{< ref "/docs/get-started/start-server.md" >}}
+
+### Installing Docker
+
+Docker is a container engine that Minikube can use to run Kubernetes apps. Go to
+the [Docker downloads page] and choose the edition built for your OS. Follow all
+of the installation steps, then verify that you're able to run `docker` without
+using sudo:
+
+```bash
+$ docker run hello-world
+```
+
+~> **Note**: On Linux, make sure you run the [post-install steps] or this won't work without sudo
+
+[Docker downloads page]: https://hub.docker.com/search?q=&type=edition&offering=community&sort=updated_at&order=desc
+[post-install steps]: https://docs.docker.com/engine/install/linux-postinstall/
+
+### Installing Minikube
+
+Head on over to the [Minikube installation page] and follow the instructions to
+download and install `minikube`. Make sure it is installed correctly by checking
+the version:
+
+-> **Note**: Make sure that the version you see is greater than or equal to the one below
+
+```bash
+$ minikube version
+minikube version: v1.17.1
+commit: 043bdca07e54ab6e4fc0457e3064048f34133d7e
+```
+
+To start your minikube cluster, run the following. This will vary depending on what
+OS you use, so make sure you are following the instructions for your platform.
+
+[Minikube installation page]: https://minikube.sigs.k8s.io/docs/start/
+
+{{< tabs tabTotal="2" tabID="1" tabName1="Mac" tabName2="Linux">}}
+
+{{< tab tabNum="1" >}}
+
+In your Mac terminal:
+
+```bash
+minikube start --driver=hyperkit --kubernetes-version=1.19.6
+```
+
+-> On Mac, `hyperkit` is provided by Docker Desktop, so you still need to install docker
+
+{{< /tab >}}
+
+{{< tab tabNum="2" >}}
+
+In your Linux terminal:
+
+```bash
+minikube start --driver=docker --kubernetes-version=1.19.6
+```
+
+{{< /tab >}}
+
+{{< /tabs >}}
+
+
+{{< caution >}}
+
+**Note**: If you see an error with `❌  Exiting due to DRV_NOT_DETECTED`, [make sure you installed docker correctly]
+
+[make sure you installed docker correctly]: {{< ref "/docs/operations/troubleshoot.md" >}}
+
+{{< /caution >}}
+
+### Installing Kubectl
+
+Minikube is nothing more than just a _mini_ Kubernetes. That means that we need to get
+the Kubernetes tool `kubectl` in order to configure and interact with our mini cluster
+just like you would with a regular cluster. Head on over to the [installing kubectl]
+page to get that installed. Once you're done, you should be able to run the following
+command to check that it's installed correctly.
+
+[installing kubectl]: https://kubernetes.io/docs/tasks/tools/install-kubectl/
+
+-> Remember, the versions you see may not match the versions shown here
+
+```bash
+$ kubectl version --short
+Client Version: v1.20.1
+Server Version: v1.19.6
+```
+
+{{<idea>}}
+
+**Note**: Minikube can download the right version of `kubectl` for you, but you have to
+access it by running `minikube kubectl -- <args>` rather than the typical `kubectl <args>`.
+If you don't want to install another tool feel free to use it this way, but just remember
+if we say to run something like `kubectl get pods`, you'll want to run
+`minikube kubectl -- get pods`
+
+{{</idea>}}
+
+### Installing Helm
+
+Helm is a package manager that makes it easy to install apps for Kubernetes. Fluvio is
+packaged as a "Helm chart" (the name for a package in Helm), and the Fluvio CLI can
+install that chart for you by calling the `helm` executable with all the right options.
+In order to do this, you need to have `helm` installed.
+
+You can install `helm` from the [helm releases page]. Once it's installed, make sure it
+works by printing the version.
+
+-> Once again, the version you see might not be the same!
+
+```bash
+$ helm version --short
+v3.3.4+ga61ce56
+```
+
+[helm releases page]: https://github.com/helm/helm/releases
+

--- a/content/docs/get-started/cli.md
+++ b/content/docs/get-started/cli.md
@@ -1,0 +1,29 @@
+---
+title: CLI Installation
+menu: CLI Installation 
+weight: 10
+---
+## Install Fluvio CLI
+
+The Fluvio CLI (_command-line interface_) is an all-in-one tool for setting up, managing, and interacting with Fluvio.
+
+* **Recommended method**: Installer script
+  * supported: MacOS/Linux 
+  * *experimental: Windows/WSL*
+
+%copy first-line%
+
+```bash
+$ curl -fsS https://packages.fluvio.io/v1/install.sh | bash
+```
+
+~> **Note**: Make sure to follow the post-installation instructions. 
+
+* Or download the Fluvio binaries from [Github Releases](https://github.com/infinyon/fluvio/releases)
+
+~> **Note**: Remember to `fluvio` binary to your shell `$PATH`
+### Fluvio CLI Plugins
+
+The installer script additionally installs the following plugins into `~/.fluvio/extensions`, which extend the functionality of the `fluvio` CLI for running a server or using Fluvio Cloud, respectively.
+* `fluvio-run`
+* `fluvio-cloud`

--- a/content/docs/get-started/cloud.md
+++ b/content/docs/get-started/cloud.md
@@ -1,6 +1,6 @@
 ---
-title: SignUp for Fluvio Cloud
-menu: Cloud
+title: Fluvio Cloud
+menu: Fluvio Cloud
 weight: 40
 ---
 
@@ -17,21 +17,13 @@ For step-by-step instruction, checkout [Getting Started with Fluvio Cloud](/docs
 
 ## Fluvio Cloud
 
-Each cloud account receives a dedicated  <a href="https://github.com/infinyon/fluvio" target="_blank">Fluvio Open Source</a> installation provisioned with 1 x [Streaming Controller](/docs/architecture/sc) (SC) and 1 x [Streaming Processing Units](/docs/architecture/spu) (SPU). 
+Each cloud account receives a dedicated <a href="https://github.com/infinyon/fluvio" target="_blank">Fluvio Open Source</a> installation provisioned with 1 x [Streaming Controller]({{< ref "/docs/architecture/cluster.md" >}}) (SC) and 1 x [Streaming Processing Units]({{< ref "/docs/architecture/cluster.md" >}}) (SPU). 
 
 <img src="../images/fluvio-cloud.svg"
      alt="Fluvio Cloud"
      style="justify: center; max-width: 360px" />
 
-[Getting Started](/docs/getting-started) provides a step-by-step guide on how to create a Fluvio Cloud account and stream "Hello World". 
-
-
 ### Data Streaming to Cloud
-
-There are currently three interfaces to stream real-time data to Fluvio Cloud:
-* [CLI](/docs/cli-reference)
-* <a href="https://infinyon.github.io/fluvio-client-node/" target="_blank">Node API</a>
-* <a href="https://docs.rs/fluvio/" target="_blank">Rust API</a>
 
 All clients require a [Profile](/docs/cli/profiles) to stream data to and from a Fluvio cluster. The profile contains the authorization and access information the client uses to register and communicate with a cluster. All data between clients and Fluvio Cloud is **encrypted** in <a href="https://en.wikipedia.org/wiki/Transport_Layer_Security" target="_blank">TLS</a>.
 
@@ -41,12 +33,16 @@ The profile is generated during cluster setup and it is available for download i
 
 When the **1GB** storage limit is reached, older data is purged to make room for new data.
 
-#### SPUs 
+#### Streaming Processor Units (SPU)
+
+For technical information about SPUs, see [Fluvio Architecture].
+
 Cloud environment does not allow changes to the number of SPUs. 
 
 Later versions will provide the ability to control **storage** and **SPU** configurations.
 
 
 #### Related Topics
-* [Getting Started](/docs/getting-started)
-* [Fluvio Architecture](/docs/architecture)
+* [Fluvio Architecture]
+
+[Fluvio Architecture]: {{< ref "/docs/architecture/overview.md" >}}

--- a/content/docs/get-started/kubernetes.md
+++ b/content/docs/get-started/kubernetes.md
@@ -1,5 +1,0 @@
----
-title: Kubernetes Installation
-menu: Kubernetes
-weight: 30
----

--- a/content/docs/get-started/linux.md
+++ b/content/docs/get-started/linux.md
@@ -1,5 +1,0 @@
----
-title: Linux Installation
-menu: Linux
-weight: 20
----

--- a/content/docs/get-started/start-server.md
+++ b/content/docs/get-started/start-server.md
@@ -1,0 +1,80 @@
+---
+title: Start Server
+menu: Start Server 
+weight: 30
+---
+
+Now that we've got all of our tools installed, let's actually get Fluvio up and running!
+If you run into any problems along the way, make sure to check out our [troubleshooting]
+page to find a fix.
+
+[troubleshooting]: {{< ref "/docs/operations/troubleshoot.md" >}}
+
+## Local server
+Currently, the local server still requires the usage of Kubernetes. Currently Fluvio stores server metadata using Kubernetes. However you can run the Fluvio processes directly on the host
+
+```bash
+$ fluvio cluster start --local
+```
+
+## Kubernetes server
+
+```bash
+$ fluvio cluster start
+✅ ok: Supported helm version is installed
+✅ ok: Fluvio system charts are installed
+✅ ok: Previous fluvio installation not found
+Waiting up to 120 seconds for Fluvio cluster version check...
+Successfully installed Fluvio!
+```
+
+You can check that everything worked by listing out the cluster's SPUs:
+
+```bash
+$ fluvio cluster spu list
+ ID  NAME    STATUS  TYPE       RACK  PUBLIC  PRIVATE 
+  0  main-0  Online  "managed"   -    :9005   fluvio-spg-main-0.fluvio-spg-main:9006
+```
+
+## Hello, Fluvio!
+
+Congratulations, you've successfully installed Fluvio on your local machine! 
+Let's use the Fluvio CLI to play with some basic functionality.
+
+The first thing we need to do is create a Fluvio topic. A Topic is like a
+category where related events live together. We can create a new topic with
+the following command:
+
+```bash
+$ fluvio topic create greetings
+topic "greetings" created
+```
+
+Now that we have a topic, we can produce some messages! Use the following
+command to send a message to the `greetings` topic:
+
+```bash
+$ echo "Hello, Fluvio" | fluvio produce greetings
+Ok!
+```
+
+Finally, we can consume messages back from the topic
+
+```bash
+$ fluvio consume greetings -B -d
+Hello, Fluvio
+```
+
+Way to go! You're well on your way to writing real-time distributed apps
+with Fluvio! Next, check out our [Tutorials page] to see real-world examples
+of Fluvio in action.
+
+[Tutorials page]: https://www.infinyon.com/tutorials 
+
+#### Related Topics
+----------------
+
+- ["Hello World" in Java](https://www.infinyon.com/tutorials/java/hello-world/)
+- ["Hello World" in Node.js](https://www.infinyon.com/tutorials/node/hello-world/)
+- ["Hello World" in Python](https://www.infinyon.com/tutorials/python/hello-world/)
+- ["Hello World" in Rust](https://www.infinyon.com/tutorials/rust/hello-world/)


### PR DESCRIPTION
* Renamed sections under Getting Started - for review
I felt like the changes respect the original new structure, but additionally focused the content into tasks

* Audit links all in Getting Started. Using ref for internal links