### PR TITLE
Add border-rounding and shadow to code blocks

### DIFF
--- a/assets/styles/_highlight.scss
+++ b/assets/styles/_highlight.scss
@@ -1,4 +1,4 @@
-/* Background */ .chroma { font-size: .9em; padding-left:10px !important; color: #f8f8f2; background-color: $code-background !important; line-height:1.65em;}
+/* Background */ .chroma { font-size: .9em; padding-left:10px !important; color: #f8f8f2; box-shadow: 5px 5px 10px lightgrey; border-radius: 5px; background-color: $code-background !important; line-height:1.65em;}
 /* Error */ .chroma .err { color: #960050; background-color: #1e0010 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
@@ -57,3 +57,4 @@
 /* GenericInserted */ .chroma .gi { color: #a6e22e }
 /* GenericStrong */ .chroma .gs { font-weight: bold }
 /* GenericSubheading */ .chroma .gu { color: #75715e }
+pre { border-radius: 5px; box-shadow: 5px 5px 10px lightgrey; }

--- a/assets/styles/_highlight.scss
+++ b/assets/styles/_highlight.scss
@@ -1,4 +1,4 @@
-/* Background */ .chroma { font-size: .9em; padding-left:10px !important; color: #f8f8f2; box-shadow: 5px 5px 10px lightgrey; border-radius: 5px; background-color: $code-background !important; line-height:1.65em;}
+/* Background */ .chroma { font-size: .9em; padding-left:10px !important; color: #f8f8f2; border-radius: 5px; background-color: $code-background !important; line-height:1.65em;}
 /* Error */ .chroma .err { color: #960050; background-color: #1e0010 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
@@ -57,4 +57,4 @@
 /* GenericInserted */ .chroma .gi { color: #a6e22e }
 /* GenericStrong */ .chroma .gs { font-weight: bold }
 /* GenericSubheading */ .chroma .gu { color: #75715e }
-pre { border-radius: 5px; box-shadow: 5px 5px 10px lightgrey; }
+pre { border-radius: 5px; }


### PR DESCRIPTION
This gives code blocks a soft raised look that I really like. It basically rounds them and raises them a bit using shadows

![image](https://user-images.githubusercontent.com/4210949/118642396-49c5fc00-b7a9-11eb-94f4-dda026fe1644.png)
