### PR TITLE
Add a SmartStream section to the CLI reference

### DIFF
--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -29,6 +29,12 @@ out with Fluvio:
 - [Produce data to a topic with `fluvio produce`](/cli/commands/produce#fluvio-produce)
 - [Consume data from a topic with `fluvio consume`](/cli/commands/consume#fluvio-consume)
 
+#### Enriching data with SmartStreams
+
+- [Quick start for building and running SmartStreams](/docs/smartstreams/quick-start)
+- [Write a custom filtering SmartStream](/docs/smartstreams/filter)
+- [Consume enriched data using SmartStreams](/cli/commands/consume#example-3-consume-using-a-smartstream)
+
 #### Viewing the status of the cluster
 
 - [See all of your topics with `fluvio topic list`](/cli/commands/topic#fluvio-topic-list)


### PR DESCRIPTION
The only CLI command we have that references SmartStreams right now is `fluvio consume --smart-stream=...` so I inflated this section in the overview with various links to other parts of the documentation for SmartStreams. In the future I expect we will have more CLI-oriented links to put here but I like this for now.