### PR TITLE
Apply blog-width to docs and news pages

### DIFF
--- a/layouts/partials/docs/doc-page.html
+++ b/layouts/partials/docs/doc-page.html
@@ -3,7 +3,7 @@
     {{- with .Site.GetPage .Section -}}{{ .Params.section }} Navigation{{- end -}}
 </div>
 
-<div class="container-fluid site-width min-height">
+<div class="container-fluid blog-width min-height">
     <div class="row">
         <div class="col-md sidebar-area">
             <div class="sidebar">

--- a/layouts/partials/news/news-page.html
+++ b/layouts/partials/news/news-page.html
@@ -1,4 +1,4 @@
-<div class="container-fluid site-width min-height">
+<div class="container-fluid blog-width min-height">
     <div class="row">
         <div class="col doc-area">
             <div class="doc">


### PR DESCRIPTION
Back when we had a blog on this site we applied a narrower width to the blog pages since it looked nice for pages that had lots of blocks of paragraph text. I think that same width applies very nicely to the `docs` and `news` pages that we have now.