### PR TITLE
Auto update the TWiF list

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -10,17 +10,3 @@ features and development updates in the [Open Source Fluvio project].
 
 [Open Source Fluvio project]: https://github.com/infinyon/fluvio
 [Fluvio]: https://fluvio.io
-
-#### Newsletters
-
-- [2021-10-21: This Week in Fluvio &#x23;11](/news/this-week-in-fluvio-0011/)
-- [2021-10-15: This Week in Fluvio &#x23;10](/news/this-week-in-fluvio-0010/)
-- [2021-10-08: This Week in Fluvio &#x23;9](/news/this-week-in-fluvio-0009/)
-- [2021-09-30: This Week in Fluvio &#x23;8](/news/this-week-in-fluvio-0008/)
-- [2021-09-23: This Week in Fluvio &#x23;7](/news/this-week-in-fluvio-0007/)
-- [2021-09-16: This Week in Fluvio &#x23;6](/news/this-week-in-fluvio-0006/)
-- [2021-09-02: This Week in Fluvio &#x23;5](/news/this-week-in-fluvio-0005/)
-- [2021-08-26: This Week in Fluvio &#x23;4](/news/this-week-in-fluvio-0004/)
-- [2021-08-19: This Week in Fluvio &#x23;3](/news/this-week-in-fluvio-0003/)
-- [2021-08-12: This Week in Fluvio &#x23;2](/news/this-week-in-fluvio-0002/)
-- [2021-08-04: This Week in Fluvio &#x23;1](/news/this-week-in-fluvio-0001/)

--- a/content/news/this-week-in-fluvio-0001.md
+++ b/content/news/this-week-in-fluvio-0001.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;1"
+title: "This Week in Fluvio #1"
 date: 2021-08-04
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0002.md
+++ b/content/news/this-week-in-fluvio-0002.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;2"
+title: "This Week in Fluvio #2"
 date: 2021-08-12
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0003.md
+++ b/content/news/this-week-in-fluvio-0003.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;3"
+title: "This Week in Fluvio #3"
 date: 2021-08-19
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0004.md
+++ b/content/news/this-week-in-fluvio-0004.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;4"
+title: "This Week in Fluvio #4"
 date: 2021-08-26
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0005.md
+++ b/content/news/this-week-in-fluvio-0005.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;5"
+title: "This Week in Fluvio #5"
 date: 2021-09-02
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0006.md
+++ b/content/news/this-week-in-fluvio-0006.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;6"
+title: "This Week in Fluvio #6"
 date: 2021-09-16
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0007.md
+++ b/content/news/this-week-in-fluvio-0007.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;7"
+title: "This Week in Fluvio #7"
 date: 2021-09-23
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0008.md
+++ b/content/news/this-week-in-fluvio-0008.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;8"
+title: "This Week in Fluvio #8"
 date: 2021-09-30
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0009.md
+++ b/content/news/this-week-in-fluvio-0009.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;9"
+title: "This Week in Fluvio #9"
 date: 2021-10-08
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0010.md
+++ b/content/news/this-week-in-fluvio-0010.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;10"
+title: "This Week in Fluvio #10"
 date: 2021-10-15
 weight: 20
 ---

--- a/content/news/this-week-in-fluvio-0011.md
+++ b/content/news/this-week-in-fluvio-0011.md
@@ -1,5 +1,5 @@
 ---
-title: "This Week in Fluvio &#x23;11"
+title: "This Week in Fluvio #11"
 date: 2021-10-21
 weight: 20
 ---

--- a/layouts/partials/news/news-list.html
+++ b/layouts/partials/news/news-list.html
@@ -8,6 +8,14 @@
                 <h1>{{ $title }}</h1>
                 <div class="doc-content">
                     {{ $content }}
+                    <h4 id="newsletters">Newsletters</h4>
+                    <ul>
+                        {{ range .Pages }}
+                        <li>
+                            <a href="{{.Permalink}}">{{.Date.Format "2006-01-02"}}: {{.Title}}</a>
+                        </li>
+                        {{ end }}
+                    </ul>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
When we make a new post, it will automatically create new entry on index.

No more manually updating the list. Sorted by date, newest at top.

Structured the same as before, so the CSS rules being applied are the same.

Fixes #186