### PR TITLE
Update smartstream to smartmodule. Fix docker commands

### DIFF
--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -244,7 +244,7 @@ $ cargo generate --git="https://github.com/infinyon/fluvio-smartmodule-template"
 ⚠️   Unable to load config file: ~/.cargo/cargo-generate.toml
 🤷   Project Name : catfact-map
 🔧   Generating template ...
-✔ 🤷   Which type of SmartStream would you like? · map
+✔ 🤷   Which type of SmartModule would you like? · map
 [1/7]   Done: .cargo/config.toml
 [2/7]   Done: .cargo
 [3/7]   Done: .gitignore

--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -174,7 +174,7 @@ And finally, when we're done with our connector, we can stop it from running usi
 
 %copy first-line%
 ```bash
-$ docker kill my-http
+$ docker kill my-http; docker rm my-http
 ```
 
 ### About Switching Profiles
@@ -240,7 +240,7 @@ Once we have it, we can use it as follows to create our SmartModule:
 
 %copy first-line%
 ```bash
-$ cargo generate --git="https://github.com/infinyon/fluvio-smartstream-template"
+$ cargo generate --git="https://github.com/infinyon/fluvio-smartmodule-template"
 ⚠️   Unable to load config file: ~/.cargo/cargo-generate.toml
 🤷   Project Name : catfact-map
 🔧   Generating template ...
@@ -278,10 +278,10 @@ to have the following contents:
 
 %copy%
 ```rust
-use fluvio_smartstream::{smartstream, Result, Record, RecordData};
+use fluvio_smartmodule::{smartmodule, Result, Record, RecordData};
 use serde_json::Value;
 
-#[smartstream(map)]
+#[smartmodule(map)]
 pub fn map(record: &Record) -> Result<(Option<RecordData>, RecordData)> {
     let input: Value = serde_json::from_slice(record.value.as_ref())?;
     let fact = &input["fact"];
@@ -327,7 +327,7 @@ SmartModule we just created, like so:
 
 %copy%
 ```bash
-docker run \
+docker run -d --name="my-http" \
     -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
     -t infinyon/fluvio-connect-http \
     -- \

--- a/content/connectors/sources/http.md
+++ b/content/connectors/sources/http.md
@@ -26,34 +26,6 @@ Additionally, the HTTP connector supports the following "Smart Connector" option
 - `map`: The name of a SmartModule to use as a map
 - `arraymap`: The name of a SmartModule to use as an arraymap
 
-### As a Local Connector
-
-When using the HTTP Connector locally, it is deployed as a Docker container. You may
-launch it with the following command:
-
-%copy%
-```bash
-docker run -d --name="my-http" \
-    -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
-    -t infinyon/fluvio-connect-http \
-    -- \
-    --endpoint="https://catfact.ninja/fact" \
-    --fluvio-topic="cat-facts" \
-    --interval=10
-```
-
-As you can see, when passing config options to a Local Connector, we use command-line
-arguments. In the above `docker` command, all arguments before the `--` are used by
-Docker itself, and all arguments after the `--` are passed to the connector.
-
-Importantly, when using a Local Connector, you _must_ include the first two arguments,
-otherwise it will not work. They are used for the following:
-
-- `-v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config"`
-  - Puts your `~/.fluvio/config` into the container, so the connector can reach your Fluvio cluster
-- `-t infinyon/fluvio-connect-http`
-  - Tells docker which image to use for the connector
-
 ### As a Managed Connector
 
 When deploying the HTTP Connector in Kubernetes alongside the Fluvio cluster, we pass
@@ -80,6 +52,34 @@ To run as a Managed Connector, use the `fluvio connector` command:
 ```bash
 $ fluvio connector create --config=./connect.yml
 ```
+
+### As a Local Connector
+
+When using the HTTP Connector locally, it is deployed as a Docker container. You may
+launch it with the following command:
+
+%copy%
+```bash
+docker run -d --name="my-http" \
+    -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
+    -t infinyon/fluvio-connect-http \
+    -- \
+    --endpoint="https://catfact.ninja/fact" \
+    --fluvio-topic="cat-facts" \
+    --interval=10
+```
+
+As you can see, when passing config options to a Local Connector, we use command-line
+arguments. In the above `docker` command, all arguments before the `--` are used by
+Docker itself, and all arguments after the `--` are passed to the connector.
+
+Importantly, when using a Local Connector, you _must_ include the first two arguments,
+otherwise it will not work. They are used for the following:
+
+- `-v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config"`
+    - Puts your `~/.fluvio/config` into the container, so the connector can reach your Fluvio cluster
+- `-t infinyon/fluvio-connect-http`
+    - Tells docker which image to use for the connector
 
 ## Data Events
 

--- a/content/connectors/sources/mqtt.md
+++ b/content/connectors/sources/mqtt.md
@@ -26,32 +26,6 @@ The MQTT connector may be deployed as a Local Connector or a Managed Connector.
 See the following sections to learn how to declare the configuration options
 for each mode.
 
-### As a Local Connector
-
-To deploy MQTT as a Local Connector, we execute it via the published Docker image
-for the connector. We'll first need to make sure we have a Fluvio topic ready.
-
-%copy first-line%
-```bash
-$ fluvio topic create mqtt
-```
-
-Then, we can execute the connector with the following command:
-
-%copy%
-```bash
-docker run -d --name="my-mqtt" \
-    -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
-    -t infinyon/fluvio-connect-mqtt \
-    -- \
-    --fluvio-topic=mqtt \
-    --mqtt-url=mqtt.hsl.fi \
-    --mqtt-topic=/hfp/v2/journey/#
-```
-
-Here, everything before the `--` is a docker argument, and everything after
-`--` is an argument to the connector.
-
 ### As a Managed Connector
 
 To deploy MQTT as a Managed Connector, we need to create a configuration file,
@@ -78,6 +52,32 @@ like this:
 ```bash
 $ fluvio connector create --config=./connect.yml
 ```
+
+### As a Local Connector
+
+To deploy MQTT as a Local Connector, we execute it via the published Docker image
+for the connector. We'll first need to make sure we have a Fluvio topic ready.
+
+%copy first-line%
+```bash
+$ fluvio topic create mqtt
+```
+
+Then, we can execute the connector with the following command:
+
+%copy%
+```bash
+docker run -d --name="my-mqtt" \
+    -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
+    -t infinyon/fluvio-connect-mqtt \
+    -- \
+    --fluvio-topic=mqtt \
+    --mqtt-url=mqtt.hsl.fi \
+    --mqtt-topic=/hfp/v2/journey/#
+```
+
+Here, everything before the `--` is a docker argument, and everything after
+`--` is an argument to the connector.
 
 ## Data Events
 

--- a/content/connectors/sources/mqtt.md
+++ b/content/connectors/sources/mqtt.md
@@ -40,7 +40,7 @@ Then, we can execute the connector with the following command:
 
 %copy%
 ```bash
-docker run \
+docker run -d --name="my-mqtt" \
     -v"$HOME/.fluvio/config:/home/fluvio/.fluvio/config" \
     -t infinyon/fluvio-connect-mqtt \
     -- \


### PR DESCRIPTION
After a last run-through, I spotted a few places where we needed updates. With these changes, following the whole doc using copy/paste works as expected.