### PR TITLE
Update `SmartStream` to `SmartModule` in docs

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ img: "images/assets/fluvio-social.png"
 twitter-card: summary_large_image
 jumbotron:
   title: "Programmable platform for data in motion"
-  description: "An open source-data streaming platform with in-line computation capabilities. Apply your [custom programs](/docs/smartstreams/quick-start) to aggregate, correlate, and transform data records in real-time as they move over the network."
+  description: "An open source-data streaming platform with in-line computation capabilities. Apply your [custom programs](/docs/smartmodules/quick-start) to aggregate, correlate, and transform data records in real-time as they move over the network."
   imageLarge: "/images/assets/fluvio-oss-large.svg"
   imageSmall: "/images/assets/fluvio-oss-small.svg"
   alt: "Fluvio SmartModules"

--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -32,8 +32,8 @@ out with Fluvio:
 
 #### Enriching data with SmartStreams
 
-- [Quick start for building and running SmartStreams]({{< ref "/docs/smartstreams/quick-start" >}})
-- [Write a custom filtering SmartStream]({{< ref "/docs/smartstreams/filter" >}})
+- [Quick start for building and running SmartStreams]({{< ref "/docs/smartmodules/quick-start" >}})
+- [Write a custom filtering SmartStream]({{< ref "/docs/smartmodules/filter" >}})
 - [Consume enriched data using SmartStreams]({{< ref "/cli/commands/consume#example-3-consume-using-a-smartstream" >}})
 
 #### Viewing the status of the cluster

--- a/content/cli/_index.md
+++ b/content/cli/_index.md
@@ -30,11 +30,11 @@ out with Fluvio:
 - [Produce data to a topic with `fluvio produce`]({{< ref "/cli/commands/produce#fluvio-produce" >}})
 - [Consume data from a topic with `fluvio consume`]({{< ref "/cli/commands/consume#fluvio-consume" >}})
 
-#### Enriching data with SmartStreams
+#### Enriching data with SmartModules
 
-- [Quick start for building and running SmartStreams]({{< ref "/docs/smartmodules/quick-start" >}})
-- [Write a custom filtering SmartStream]({{< ref "/docs/smartmodules/filter" >}})
-- [Consume enriched data using SmartStreams]({{< ref "/cli/commands/consume#example-3-consume-using-a-smartstream" >}})
+- [Quick start for building and running SmartModules]({{< ref "/docs/smartmodules/quick-start" >}})
+- [Write a custom filtering SmartModule]({{< ref "/docs/smartmodules/filter" >}})
+- [Consume enriched data using SmartModules]({{< ref "/cli/commands/consume#example-3-consume-using-a-smartstream" >}})
 
 #### Viewing the status of the cluster
 

--- a/content/cli/commands/consume.md
+++ b/content/cli/commands/consume.md
@@ -41,8 +41,8 @@ OPTIONS:
     -T, --tail <integer>           Consume records starting X from the end of the log (default: 10)
     -b, --maxbytes <integer>       Maximum number of bytes to be retrieved
     -O, --output <type>            Output [possible values: dynamic, text, binary, json, raw]
-        --filter <filter>          Path to a SmartStream filter wasm file
-        --map <map>                Path to a SmartStream map wasm file
+        --filter <filter>          Path to a SmartModule filter wasm file
+        --map <map>                Path to a SmartModule map wasm file
         --aggregate <aggregate>    Path to a WASM file for aggregation
         --initial <initial>        (Optional) Path to a file to use as an initial accumulator value
                                    with --aggregate
@@ -94,22 +94,22 @@ $ fluvio consume my-topic -B -d --key-value
 
 Records that were not given a key are printed with `[null]`.
 
-## Example 3: Consume using a SmartStream
+## Example 3: Consume using a SmartModule
 
-Fluvio SmartStreams are WASM modules that can edit the contents of a stream
+Fluvio SmartModules are WASM modules that can edit the contents of a stream
 inline, before the records of that stream are delivered to a consumer. In order
-to use SmartStreams, you must supply the WASM module to the `fluvio consume`
-command using the SmartStream options: `--filter`, `--map`, `--aggregate`.
+to use SmartModules, you must supply the WASM module to the `fluvio consume`
+command using the SmartModule options: `--filter`, `--map`, `--aggregate`.
 
-The simplest SmartStream is the [filter example from the quick-start], which
+The simplest SmartModule is the [filter example from the quick-start], which
 filters records from the stream based on whether they contain the letter `a`
 or not. You can find the full example code [in our GitHub repo] and compile
 it to test out yourself.
 
-[filter example from the quick-start]: {{< ref "/docs/smartstreams/quick-start" >}}
-[in our GitHub repo]: https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartstream/examples/filter_json
+[filter example from the quick-start]: {{< ref "/docs/smartmodules/quick-start" >}}
+[in our GitHub repo]: https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartmodule/examples/filter_json
 
-Once you have compiled your SmartStream Filter and have a `.wasm` file for it, you
+Once you have compiled your SmartModule Filter and have a `.wasm` file for it, you
 can apply it to the consumer as follows:
 
 %copy first-line%

--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -269,7 +269,7 @@ JSON objects that our connector fetches for us. Add the following line to the
 
 {{< highlight bash "hl_lines=3" >}}
 [dependencies]
-fluvio-smartstream = { version = "0.3" }
+fluvio-smartmodule = { version = "0.3" }
 serde_json = "1"
 {{</ highlight >}}
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -15,8 +15,8 @@ At the base level, Fluvio has a distributed, immutable, persistent log store
 written from the ground up in Rust. At the next level up is an asynchronous
 and horizontally scalable data streaming layer for low-latency delivery of
 stream events. Built on this streaming layer is Fluvio's programmable
-SmartStreams, which allow users to perform inline computations on streaming
-data without leaving the cluster. SmartStreams are powered by WebAssembly
+SmartModules, which allow users to perform inline computations on streaming
+data without leaving the cluster. SmartModules are powered by WebAssembly
 modules containing custom user-written code, which are granted access to
 filter, transform, and otherwise modify the data flowing from the stream.
 Fluvio provides client libraries for several popular programming languages

--- a/content/docs/smartmodules/_index.md
+++ b/content/docs/smartmodules/_index.md
@@ -1,5 +1,5 @@
 ---
-title: SmartStreams
+title: SmartModules
 weight: 50
 _build:
   render: never

--- a/content/docs/smartmodules/aggregate.md
+++ b/content/docs/smartmodules/aggregate.md
@@ -4,21 +4,21 @@ weight: 40
 toc: false
 ---
 
-SmartStream Aggregates are functions that define how to combine each record
+SmartModule Aggregates are functions that define how to combine each record
 in a stream with some accumulated value. In the functional programming world,
 this type of operation is also known as `folding`, since the function "folds"
 each new value into the accumulator.
 
-Let's set up a new SmartStream project so that we can look at some code while
-introducing aggregators. Use `cargo-generate` to create a new SmartStream project,
+Let's set up a new SmartModule project so that we can look at some code while
+introducing aggregators. Use `cargo-generate` to create a new SmartModule project,
 and be sure to select the "aggregate" type during setup.
 
 ```bash
 $ cargo install cargo-generate
-$ cargo generate --git https://github.com/infinyon/fluvio-smartstream-template
+$ cargo generate --git https://github.com/infinyon/fluvio-smartmodule-template
 🤷   Project Name : example-aggregate
 🔧   Creating project called `example-aggregate`...
-✔ 🤷   Which type of SmartStream would you like? · aggregate
+✔ 🤷   Which type of SmartModule would you like? · aggregate
 [1/5]   Done: .cargo/config.toml
 [2/5]   Done: .gitignore
 [3/5]   Done: Cargo.toml
@@ -30,9 +30,9 @@ $ cargo generate --git https://github.com/infinyon/fluvio-smartstream-template
 Let's take a look at the starter code from the template, located in `src/lib.rs`.
 
 ```rust
-use fluvio_smartstream::{smartstream, Result, Record, RecordData};
+use fluvio_smartmodule::{smartmodule, Result, Record, RecordData};
 
-#[smartstream(aggregate)]
+#[smartmodule(aggregate)]
 pub fn aggregate(accumulator: RecordData, current: &Record) -> Result<RecordData> {
   // Parse the accumulator and current record as strings
   let accumulator_string = std::str::from_utf8(accumulator.as_ref())?;
@@ -71,5 +71,5 @@ to convert the String to a `RecordData`.
 ### Read next
 
 - [Explore aggregate use-cases](https://www.infinyon.com/blog/2021/08/smartstream-aggregates/)
-- [Writing a JSON filter]({{< ref "/docs/smartstreams/filter" >}})
-- [Writing a map to transform records]({{< ref "/docs/smartstreams/map" >}})
+- [Writing a JSON filter]({{< ref "/docs/smartmodules/filter" >}})
+- [Writing a map to transform records]({{< ref "/docs/smartmodules/map" >}})

--- a/content/docs/smartmodules/api.md
+++ b/content/docs/smartmodules/api.md
@@ -4,13 +4,13 @@ weight: 40
 toc: false
 ---
 
-You can pass the SmartStream filter when creating consumer thru API.  Here, we are using the Rust client library.
+You can pass the SmartModule filter when creating consumer thru API.  Here, we are using the Rust client library.
 
 This guide assumes you are familiar with [Rust Client API]({{< ref "/docs/interfaces/apis" >}})
 
 ### Write Filter
 
-Follow steps in [filter]({{< ref "/docs/smartstreams/filter" >}}) guide to write your own SmartStream filter.
+Follow steps in [filter]({{< ref "/docs/smartmodules/filter" >}}) guide to write your own SmartModule filter.
 
 
 ### Create Partition Consumer with filter

--- a/content/docs/smartmodules/array-map.md
+++ b/content/docs/smartmodules/array-map.md
@@ -4,7 +4,7 @@ weight: 35
 toc: false
 ---
 
-SmartStream ArrayMaps are used to break apart Records into smaller pieces.
+SmartModule ArrayMaps are used to break apart Records into smaller pieces.
 This can be very useful for working with your data at a fine granularity.
 Often, each record in a Topic may actually represent many data points, but
 we'd like to be able to analyze and manipulate those data points independently.
@@ -39,7 +39,7 @@ elements of those arrays, similar to the input and output we saw above.
 
 ### Create a new Project
 
-We can use the `cargo-generate` tool to create a new SmartStreams project that
+We can use the `cargo-generate` tool to create a new SmartModules project that
 is ready to go. If you don't already have it, you can install `cargo-generate`
 using this command:
 
@@ -48,15 +48,15 @@ using this command:
 $ cargo install cargo-generate
 ```
 
-Then, use the following command to create a new SmartStreams ArrayMap project.
+Then, use the following command to create a new SmartModules ArrayMap project.
 
 %copy first-line%
 ```bash
-$ cargo generate --git="https://github.com/infinyon/fluvio-smartstream-template"
+$ cargo generate --git="https://github.com/infinyon/fluvio-smartmodule-template"
 ⚠️   Unable to load config file: ~/.cargo/cargo-generate.toml
 🤷   Project Name : array-map-array
 🔧   Generating template ...
-✔ 🤷   Which type of SmartStream would you like? · array-map
+✔ 🤷   Which type of SmartModule would you like? · array-map
 [1/7]   Done: .cargo/config.toml
 [2/7]   Done: .cargo
 [3/7]   Done: .gitignore
@@ -82,9 +82,9 @@ at the full source, then we'll cover it piece by piece. Let's look at
 
 %copy%
 ```rust
-use fluvio_smartstream::{smartstream, Record, RecordData, Result};
+use fluvio_smartmodule::{smartmodule, Record, RecordData, Result};
 
-#[smartstream(array_map)]
+#[smartmodule(array_map)]
 pub fn array_map(record: &Record) -> Result<Vec<(Option<RecordData>, RecordData)>> {
     // Deserialize a JSON array with any kind of values inside
     let array: Vec<serde_json::Value> = serde_json::from_slice(record.value.as_ref())?;
@@ -124,7 +124,7 @@ for Rust using the following command:
 $ rustup target add wasm32-unknown-unknown
 ```
 
-Now we'll be able to compile the ArrayMap SmartStream. Let's use release mode so
+Now we'll be able to compile the ArrayMap SmartModule. Let's use release mode so
 we get the smallest WASM binary possible:
 
 %copy first-line%
@@ -151,7 +151,7 @@ Ok!
 > ^C
 ```
 
-Finally, let's consume our data using our ArrayMap SmartStream and see that each
+Finally, let's consume our data using our ArrayMap SmartModule and see that each
 of the output records shows just one of the elements from each input array.
 
 %copy first-line%
@@ -164,13 +164,13 @@ $ fluvio consume array-map -B --array-map=target/wasm32-unknown-unknown/release/
 
 Congratulations, you just completed your first ArrayMap example! You can find the
 [full source code for this example on GitHub], along with the full sources for many
-other SmartStreams examples.
+other SmartModules examples.
 
 ### Read next
 
 - [Explore map use-cases](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/)
-- [Writing a JSON filter]({{< ref "/docs/smartstreams/filter" >}})
-- [Writing an aggregate to sum numbers]({{< ref "/docs/smartstreams/aggregate" >}})
+- [Writing a JSON filter]({{< ref "/docs/smartmodules/filter" >}})
+- [Writing an aggregate to sum numbers]({{< ref "/docs/smartmodules/aggregate" >}})
 
 [downloaded the Fluvio CLI]: https://www.fluvio.io/download/
 [using ArrayMap to break apart paginated API requests]: https://infinyon.com/blog/2021/10/smartstream-array-map-reddit/

--- a/content/docs/smartmodules/filter.md
+++ b/content/docs/smartmodules/filter.md
@@ -44,11 +44,12 @@ $ cargo generate --git https://github.com/infinyon/fluvio-smartmodule-template
 [3/5]   Done: Cargo.toml
 [4/5]   Done: README.md
 [5/5]   Done: src/lib.rs
-✨   Done! New project created json-filter```
+✨   Done! New project created json-filter
+```
 
 In the new project, let's add the `serde` and `serde_json` dependencies:
 
-```toml
+{{< highlight bash "hl_lines=13-14" >}}
 # Cargo.toml
 [package]
 name = "json-filter"
@@ -60,16 +61,16 @@ edition = "2018"
 crate-type = ['cdylib']
 
 [dependencies]
+fluvio-smartmodule = { version = "0.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-fluvio-smartmodule = { version = "0.1" }
 
 [workspace]
 members = ["."]
 
 [profile.release]
 lto = true
-```
+{{</ highlight >}}
 
 Alright, now that we have our setup all ready, let's talk about what we're going to
 be filtering.
@@ -187,6 +188,7 @@ In other words, we actually want to keep the records that are "more important" o
 "greater than" `LogLevel::Debug`. Since we have implemented `Ord` for `LogLevel`, this
 will be a piece of cake! Let's look at all the code for the finished filter.
 
+%copy%
 ```rust
 use fluvio_smartmodule::{smartmodule, Record, Result};
 

--- a/content/docs/smartmodules/filter.md
+++ b/content/docs/smartmodules/filter.md
@@ -4,7 +4,7 @@ weight: 20
 toc: false
 ---
 
-The simplest type of SmartStream is a filter, which can examine each record in
+The simplest type of SmartModule is a filter, which can examine each record in
 a stream and decide whether to accept or reject it. All records that are accepted
 by a filter will be delivered down the pipeline to the consumer, but records that
 are rejected will be discarded from the stream. Note that this does not mean that
@@ -13,19 +13,19 @@ those records are not delivered to the consumer.
 
 ### Getting Practical: Filter Records by JSON fields
 
-Since we already had a quick introduction to Filters in the [SmartStream quick start]
+Since we already had a quick introduction to Filters in the [SmartModule quick start]
 guide, let's try something a little fancier. In this example, we're going to filter
-records based on the contents of their JSON fields. Since SmartStreams are written
+records based on the contents of their JSON fields. Since SmartModules are written
 using arbitrary Rust code, we can also pull in other crates as dependencies. We're
 going to use `serde` and `serde_json` to help us work with our JSON data.
 If you want to jump ahead and see the finished code, [check out our JSON filter example].
 
-[SmartStream quick start]: {{< ref "/docs/smartstreams/quick-start" >}}
-[check out our JSON filter example]: https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartstream/examples/filter_json
+[SmartModule quick start]: {{< ref "/docs/smartmodules/quick-start" >}}
+[check out our JSON filter example]: https://github.com/infinyon/fluvio/tree/master/crates/fluvio-smartmodule/examples/filter_json
 
 #### Create a new Project
 
-Let's use `cargo-generate` again to set up our new SmartStream project. We'll want
+Let's use `cargo-generate` again to set up our new SmartModule project. We'll want
 to give the project a name and choose the "filter" option.
 
 %copy first-line%
@@ -35,10 +35,10 @@ $ cargo install cargo-generate # In case you didn't install it before
 
 %copy first-line%
 ```bash
-$ cargo generate --git https://github.com/infinyon/fluvio-smartstream-template
+$ cargo generate --git https://github.com/infinyon/fluvio-smartmodule-template
 🤷   Project Name : json-filter
 🔧   Creating project called `json-filter`...
-✔ 🤷   Which type of SmartStream would you like? · filter
+✔ 🤷   Which type of SmartModule would you like? · filter
 [1/5]   Done: .cargo/config.toml
 [2/5]   Done: .gitignore
 [3/5]   Done: Cargo.toml
@@ -62,7 +62,7 @@ crate-type = ['cdylib']
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-fluvio-smartstream = { version = "0.2.0" }
+fluvio-smartmodule = { version = "0.1" }
 
 [workspace]
 members = ["."]
@@ -85,7 +85,7 @@ the event that occurred.
 
 For the purposes of this exercise, let's say we have a file that we've stored our logs
 into, so that we can manually produce them to a Fluvio topic and consume them back
-using our JSON SmartStream. Create a file called `server.log` with the following
+using our JSON SmartModule. Create a file called `server.log` with the following
 contents:
 
 ```bash
@@ -119,9 +119,9 @@ Let's look at the starter code that we got when we created our Filter template.
 
 ```rust
 // src/lib.rs
-use fluvio_smartstream::{smartstream, Record, Result};
+use fluvio_smartmodule::{smartmodule, Record, Result};
 
-#[smartstream(filter)]
+#[smartmodule(filter)]
 pub fn filter(record: &Record) -> Result<bool> {
     let string = std::str::from_utf8(record.value.as_ref())?;
     Ok(string.contains('a'))
@@ -170,9 +170,9 @@ Now, let's write the logic for our filter. We'll start by parsing our raw data i
 instances of `StructuredLog`.
 
 ```rust
-use fluvio_smartstream::{smartstream, Record, Result};
+use fluvio_smartmodule::{smartmodule, Record, Result};
 
-#[smartstream(filter)]
+#[smartmodule(filter)]
 fn filter(record: &Record) -> Result<bool> {
     let log: StructuredLog = serde_json::from_slice(record.value.as_ref())?;
     
@@ -180,7 +180,7 @@ fn filter(record: &Record) -> Result<bool> {
 }
 ```
 
-For `fluvio_smartstream::Result`, we can bubble-up Results using the `?` operator.
+For `fluvio_smartmodule::Result`, we can bubble-up Results using the `?` operator.
 
 Now for the final step, we want our filter to accept all records except for "debug" logs.
 In other words, we actually want to keep the records that are "more important" or
@@ -188,7 +188,7 @@ In other words, we actually want to keep the records that are "more important" o
 will be a piece of cake! Let's look at all the code for the finished filter.
 
 ```rust
-use fluvio_smartstream::{smartstream, Record, Result};
+use fluvio_smartmodule::{smartmodule, Record, Result};
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -206,7 +206,7 @@ struct StructuredLog {
     _message: String,
 }
 
-#[smartstream(filter)]
+#[smartmodule(filter)]
 fn filter(record: &Record) -> Result<bool> {
     let log: StructuredLog = serde_json::from_slice(record.value.as_ref())?;
 
@@ -248,7 +248,7 @@ $ fluvio topic create server-logs
 topic "server-logs" created
 ```
 
-In order to see the impact of our SmartStream filter, let's open two terminals,
+In order to see the impact of our SmartModule filter, let's open two terminals,
 with each running a consumer that watches our `server-logs` topic. One of these
 will be a plain consumer that consumes _all_ the records, and the other one will
 use our filter, so we should only see non-debug logs.
@@ -260,7 +260,7 @@ To run the plain consumer, use the following command:
 $ fluvio consume server-logs -B
 ```
 
-In the other terminal, run a consumer with the SmartStream filter using this command:
+In the other terminal, run a consumer with the SmartModule filter using this command:
 
 %copy first-line%
 ```bash
@@ -294,7 +294,7 @@ $ fluvio consume server-logs -B
 {"level":"error","message":"Unable to connect to database"}
 ```
 
-But in the consumer with our SmartStream, we'll no longer see any of the records
+But in the consumer with our SmartModule, we'll no longer see any of the records
 whose log level was debug!
 
 %copy first-line%
@@ -310,5 +310,5 @@ $ fluvio consume server-logs -B --filter="target/wasm32-unknown-unknown/release/
 ### Read next
 
 - [Explore filter use-cases](https://www.infinyon.com/blog/2021/06/smartstream-filters/)
-- [Writing a map to transform records]({{< ref "/docs/smartstreams/map" >}})
-- [Writing an aggregate to sum numbers]({{< ref "/docs/smartstreams/aggregate" >}})
+- [Writing a map to transform records]({{< ref "/docs/smartmodules/map" >}})
+- [Writing an aggregate to sum numbers]({{< ref "/docs/smartmodules/aggregate" >}})

--- a/content/docs/smartmodules/map.md
+++ b/content/docs/smartmodules/map.md
@@ -4,21 +4,21 @@ weight: 30
 toc: false
 ---
 
-SmartStream Maps are used to transform or edit each Record in a stream.
-We say that these SmartStreams "map" each input record into a new output
-record by applying a function to the input data. This type of SmartStream
+SmartModule Maps are used to transform or edit each Record in a stream.
+We say that these SmartModules "map" each input record into a new output
+record by applying a function to the input data. This type of SmartModule
 may be used for many use-cases, such as:
 
 - Narrowing large records into a smaller subset of important fields
 - Scrubbing sensitive fields of data to be invisible to downstream consumers
 - Computing rich, derived fields from simple raw data
 
-Let's create a brand-new SmartStream Map to see what a minimal working
+Let's create a brand-new SmartModule Map to see what a minimal working
 example looks like.
 
 ### Create a new Project
 
-Let's use `cargo-generate` to set up a blank SmartStream Map project. If you
+Let's use `cargo-generate` to set up a blank SmartModule Map project. If you
 don't have it yet, run the following command to install it:
 
 %copy first-line%
@@ -30,10 +30,10 @@ Then, run the following command and be sure to select the `map` option.
 
 %copy first-line%
 ```bash
-$ cargo generate --git https://github.com/infinyon/fluvio-smartstream-template
+$ cargo generate --git https://github.com/infinyon/fluvio-smartmodule-template
 🤷   Project Name : map-example
 🔧   Creating project called `map-example`...
-🤷   Which type of SmartStream would you like? [filter, map] [default: filter]: map
+🤷   Which type of SmartModule would you like? [filter, map] [default: filter]: map
 [1/5]   Done: .cargo/config.toml
 [2/5]   Done: .gitignore
 [3/5]   Done: Cargo.toml
@@ -47,9 +47,9 @@ can go inside and take a look at the sample Map generated for us by the template
 
 %copy%
 ```rust
-use fluvio_smartstream::{smartstream, Result, Record, RecordData};
+use fluvio_smartmodule::{smartmodule, Result, Record, RecordData};
 
-#[smartstream(map)]
+#[smartmodule(map)]
 pub fn map(record: &Record) -> Result<(Option<RecordData>, RecordData)> {
     let key = record.key.clone();
 
@@ -63,7 +63,7 @@ pub fn map(record: &Record) -> Result<(Option<RecordData>, RecordData)> {
 
 Let's break down what's happening here:
 
-- Firstly, `#[smartstream(map)]` marks the entry point for this SmartStream Map.
+- Firstly, `#[smartmodule(map)]` marks the entry point for this SmartModule Map.
   There may only be one of these in the project, and it is called once for each
   record in the data stream.
 - The annotated function `fn map` may be named anything, but it must take a
@@ -73,15 +73,15 @@ Let's break down what's happening here:
   The Key is the `Option<RecordData>` and the Value is the `RecordData` in the
   return type. `RecordData` is a helper type that may be constructed from any
   type that has `impl Into<Vec<u8>>` such as `String`, by using `.into()`.
-- At any point in the SmartStream, errors may be returned using `?` or via
+- At any point in the SmartModule, errors may be returned using `?` or via
   `Err(e.into())`. This works for any error type that has `impl std::error::Error`.
 
-This template SmartStream will parse each record as an `i32` integer, then
+This template SmartModule will parse each record as an `i32` integer, then
 multiply that value by 2. To test it out, make sure you are connected to an
 active Fluvio Cluster (see the getting started sections in the top left), then
 follow the instructions in the next section:
 
-### How to run a SmartStream Map with a consumer
+### How to run a SmartModule Map with a consumer
 
 Create a new Topic:
 
@@ -91,7 +91,7 @@ $ fluvio topic create map-double
 topic "map-double" created
 ```
 
-Build the SmartStream WASM module. In your project folder, run:
+Build the SmartModule WASM module. In your project folder, run:
 
 %copy first-line%
 ```bash
@@ -143,5 +143,5 @@ Consuming records from the beginning of topic 'map-double'
 ### Read next
 
 - [Explore map use-cases](https://www.infinyon.com/blog/2021/08/smartstream-map-use-cases/)
-- [Writing a JSON filter]({{< ref "/docs/smartstreams/filter" >}})
-- [Writing an aggregate to sum numbers]({{< ref "/docs/smartstreams/aggregate" >}})
+- [Writing a JSON filter]({{< ref "/docs/smartmodules/filter" >}})
+- [Writing an aggregate to sum numbers]({{< ref "/docs/smartmodules/aggregate" >}})

--- a/content/docs/smartmodules/quick-start.md
+++ b/content/docs/smartmodules/quick-start.md
@@ -62,7 +62,7 @@ pub fn filter(record: &Record) -> Result<bool>7 {
 
 The function with the `#[smartmodule(filter)]` attribute is the entrypoint to the
 SmartModule. The SPU that processes our stream will send each Record to this
-function and, based on whether the function returns Ok(true) or not, either send
+function and, based on whether the function returns `Ok(true)` or not, either send
 the record to our consumer or not. This sample SmartModule will check whether
 the record's contents are a UTF-8 string and whether that string contains the
 letter `a`.
@@ -75,6 +75,7 @@ command:
 
 [rustup]: https://rustup.rs
 
+%copy first-line%
 ```bash
 $ rustup target add wasm32-unknown-unknown
 ```
@@ -156,6 +157,7 @@ If everything worked as expected, we should see all five records appear in the
 plain consumer, but only `Banana`, `Cabbage`, and `Date` should appear in the
 consumer with our SmartModule filter.
 
+%copy first-line%
 ```bash
 $ fluvio consume hello-smartmodules -B
 Apple

--- a/content/news/this-week-in-fluvio-0011.md
+++ b/content/news/this-week-in-fluvio-0011.md
@@ -129,7 +129,7 @@ Consuming records from the end of topic 'array-map-array'. This will wait for ne
 "Cranberry"
 ```
 
-Docs for ArrayMap are [available here]({{< ref "/docs/smartstreams/array-map.md" >}}). For a more hands-on explanation with a real-world example, please read our [blog post](https://infinyon.com/blog/2021/10/smartstream-array-map-reddit/) demonstrating the capabilities of `#[smartstream(array_map)]`.
+Docs for ArrayMap are [available here]({{< ref "/docs/smartmodules/array-map.md" >}}). For a more hands-on explanation with a real-world example, please read our [blog post](https://infinyon.com/blog/2021/10/smartstream-array-map-reddit/) demonstrating the capabilities of `#[smartstream(array_map)]`.
 
 
 ---

--- a/netlify.toml
+++ b/netlify.toml
@@ -68,4 +68,40 @@
   from = "/blog/"
   to = "https://www.infinyon.com/blog/"
   status = 301
-  force = true 
+  force = true
+
+[[redirects]]
+from = "/docs/smartstreams/quick-start/"
+to = "/docs/smartmodules/quick-start/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/smartstreams/filter/"
+to = "/docs/smartmodules/filter/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/smartstreams/map/"
+to = "/docs/smartmodules/map/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/smartstreams/array-map/"
+to = "/docs/smartmodules/array-map/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/smartstreams/aggregate/"
+to = "/docs/smartmodules/aggregate/"
+status = 301
+force = true
+
+[[redirects]]
+from = "/docs/smartstreams/api/"
+to = "/docs/smartmodules/api/"
+status = 301
+force = true


### PR DESCRIPTION
This PR changes all references of `SmartStream` to `SmartModule` following the recent renaming. There should no longer be any reference to "SmartStream" except for within URLs to the InfinyOn site.