### PR TITLE
Twif 20 - Add note about Apple M1 support

### DIFF
--- a/content/news/this-week-in-fluvio-0020.md
+++ b/content/news/this-week-in-fluvio-0020.md
@@ -19,6 +19,8 @@ We'll approach connector development in this order:
 3. [Load your Connector image into Kubernetes Cluster]({{<ref "#load-your-connector-image-into-kubernetes-cluster">}})
 4. [Create a new Connector in Fluvio]({{<ref "#create-a-new-connector-in-fluvio">}})
 
+The code and configuration for this are available in the [fluvio-connectors examples](https://github.com/infinyon/fluvio-connectors/tree/main/examples/python-client-connector).
+
 ### Tools needed to follow this guide
 
 You'll need the following tools installed
@@ -223,6 +225,13 @@ Load image to `minikube`:
 $ minikube image load infinyon/fluvio-connect-cat-facts
 ```
 
+You can verify the image has been loaded into minikube
+
+%copy first-line%
+```shell
+$ minikube image ls
+docker.io/infinyon/fluvio-connect-cat-facts:latest
+```
 {{</ tab >}}
 
 {{</ tabs >}}

--- a/content/news/this-week-in-fluvio-0020.md
+++ b/content/news/this-week-in-fluvio-0020.md
@@ -29,6 +29,9 @@ You'll need the following tools installed
 - [Docker](https://www.docker.com/get-started)
 - Kubernetes distros ([k3d](https://k3d.io/) or [minikube](https://minikube.sigs.k8s.io/docs/start/))
 
+#### Note
+At the time of this writing, Apple M1 (aarch64) is not supported due to lack of build support, and will be unable to follow this walkthrough. See https://github.com/pypa/cibuildwheel/issues/598
+
 ## Build and Run Your Client Locally
 
 Let's start with building a simple client.


### PR DESCRIPTION
There's an upstream bug that prevents us from building Python packages for aarch64 (The platform that Apple M1 uses)

Added extra instruction for verifying image load for minikube