### PR TITLE
fix recommended kind config for mac m1 getting started docs 

### DIFF
--- a/content/docs/get-started/mac_m1.md
+++ b/content/docs/get-started/mac_m1.md
@@ -48,17 +48,17 @@ nodes:
   - role: control-plane
     # port forward 80 on the host to 80 on this node
     extraPortMappings:
-      - containerPort: 31003 #sc
-        hostPort: 31003
+      - containerPort: 30003 #sc
+        hostPort: 30003
         protocol: TCP
-      - containerPort: 31004 #spu 1
-        hostPort: 31004
+      - containerPort: 30004 #spu 1
+        hostPort: 30004
         protocol: TCP
-      - containerPort: 31005 #spu 2
-        hostPort: 31005
+      - containerPort: 30005 #spu 2
+        hostPort: 30005
         protocol: TCP
-      - containerPort: 31006 #spu 3
-        hostPort: 31006
+      - containerPort: 30006 #spu 3
+        hostPort: 30006
         protocol: TCP
 
 ```


### PR DESCRIPTION
Adjust the recommend kind configuration to map the correct node ports based on the defaults set in the Helm Chart for the fluvio install.

closes #259