### PR TITLE
Deprecate connectors create topic

### DIFF
--- a/content/cli/commands/connector.md
+++ b/content/cli/commands/connector.md
@@ -46,7 +46,7 @@ Here's a description of the available options:
 - `name`: The name given to the instance of the connector when it is created
 - `type`: The type of connector. This corresponds to the name of the docker image
   that this connector is published in, e.g. `infinyon/fluvio-connect-<type>`
-- `topic`: The name of the Fluvio topic that this connector will produce to
+- `topic`: The name of the Fluvio topic that this connector will produce to.
 - `direction`: Whether the connector is a `source` or a `sink` connector
 - `parameters`: An object that contains connector-specific parameters.
   Also, connectors that support SmartModules specify their SmartModule names here:
@@ -55,6 +55,7 @@ Here's a description of the available options:
   - `arraymap`: The name of an ArrayMap SmartModule to apply
 
 -> **Note**: Currently, `aggregate` and `filter-map` SmartModules are not supported in connectors.
+-> **Note**: The Fluvio topic set in `topic` will be automatically created if the Fluvio `topic` does not exist.
 
 When running `fluvio connector create`, pass the path to this file using the `--config`
 option.

--- a/content/cli/commands/connector.md
+++ b/content/cli/commands/connector.md
@@ -34,7 +34,6 @@ api_version: v1
 name: cat-facts
 type: http
 topic: cat-facts
-create_topic: true
 direction: source
 parameters:
   endpoint: https://catfact.ninja/fact
@@ -48,7 +47,6 @@ Here's a description of the available options:
 - `type`: The type of connector. This corresponds to the name of the docker image
   that this connector is published in, e.g. `infinyon/fluvio-connect-<type>`
 - `topic`: The name of the Fluvio topic that this connector will produce to
-- `create_topic`: Whether to create the topic if it does not exist
 - `direction`: Whether the connector is a `source` or a `sink` connector
 - `parameters`: An object that contains connector-specific parameters.
   Also, connectors that support SmartModules specify their SmartModule names here:

--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -62,7 +62,6 @@ api_version: v1
 name: cat-facts
 type: http
 topic: cat-facts
-create_topic: true
 direction: source
 parameters:
   endpoint: https://catfact.ninja/fact
@@ -339,7 +338,6 @@ api_version: v1
 name: cat-facts
 type: http
 topic: cat-facts
-create_topic: true
 direction: source
 parameters:
   endpoint: https://catfact.ninja/fact

--- a/content/connectors/examples/github.md
+++ b/content/connectors/examples/github.md
@@ -43,7 +43,6 @@ api_version: v1
 name: github-repo
 type: http
 topic: github-repo
-create_topic: true
 direction: source
 parameters:
   endpoint: https://api.github.com/repos/infinyon/fluvio
@@ -325,7 +324,6 @@ api_version: v1
 name: github-repo
 type: http
 topic: github-repo
-create_topic: true
 direction: source
 parameters:
   endpoint: https://api.github.com/repos/infinyon/fluvio

--- a/content/connectors/sinks/postgres.md
+++ b/content/connectors/sinks/postgres.md
@@ -27,7 +27,6 @@ version: 0.1.0
 name: my-postgres-sink
 type: postgres-sink
 topic: postgres-topic
-create_topic: true
 parameters:
   url: postgres://postgres:mysecretpassword@localhost:5432/postgres
 secrets:

--- a/content/connectors/sources/http.md
+++ b/content/connectors/sources/http.md
@@ -41,7 +41,6 @@ api_version: v1
 name: cat-facts
 type: http
 topic: cat-facts
-create_topic: true
 direction: source
 parameters:
   endpoint: https://catfact.ninja/fact

--- a/content/connectors/sources/mqtt.md
+++ b/content/connectors/sources/mqtt.md
@@ -38,7 +38,6 @@ api_version: v1
 name: my-mqtt
 type: mqtt
 topic: mqtt-topic
-create_topic: true
 direction: source
 parameters:
   mqtt-url: "mqtt.hsl.fi"

--- a/content/connectors/sources/postgres.md
+++ b/content/connectors/sources/postgres.md
@@ -47,7 +47,6 @@ version: 0.1.0
 name: my-postgres-source
 type: postgres-source
 topic: postgres-topic
-create_topic: true
 parameters:
   publication: fluvio
   slot: fluvio

--- a/content/connectors/sources/template.md
+++ b/content/connectors/sources/template.md
@@ -35,7 +35,6 @@ version: v1
 name: my-prometheus
 type: prometheus
 topic: prometheus-topic
-create_topic: true
 direction: source
 parameters:
 endpoints:

--- a/content/news/this-week-in-fluvio-0009.md
+++ b/content/news/this-week-in-fluvio-0009.md
@@ -89,7 +89,6 @@ api_version: v1
 name: my-test-connector
 type: test-connector
 topic: my-test-connector
-create_topic: true 
 direction: source
 parameters:
   topic: my-test-connector

--- a/content/news/this-week-in-fluvio-0010.md
+++ b/content/news/this-week-in-fluvio-0010.md
@@ -33,7 +33,6 @@ api_version: v1
 name: my-test-mqtt
 type: mqtt
 topic: public-mqtt
-create_topic: true
 direction: source
 parameters:
   mqtt-url: "broker.hivemq.com"

--- a/content/news/this-week-in-fluvio-0014.md
+++ b/content/news/this-week-in-fluvio-0014.md
@@ -27,7 +27,6 @@ api_version: v1
 name: my-test-mqtt
 type: mqtt
 topic: public-mqtt
-create_topic: true
 direction: source
 parameters:
   mqtt-url: "broker.hivemq.com"

--- a/content/news/this-week-in-fluvio-0020.md
+++ b/content/news/this-week-in-fluvio-0020.md
@@ -251,7 +251,7 @@ direction: source
 | `version`               | This value must be  `dev`  for local development.                                                                                                                        |
 | `name`                  | A unique name for this connector. <br><br> It will be displayed in `fluvio connector list`                                                                                                               |
 | `type`                  | The value of this name will be used for tagging image before loading into Kubernetes. <br><br> Connector image names follow the pattern: `infinyon/fluvio-connect-{type}` |
-| `topic`                 | The name of the `topic` where the connector will publish the data records. .                                                                            |
+| `topic`                 | The name of the Fluvio `topic` where the connector will publish the data records. The Fluvio `topic` will be automatically created if the Fluvio topic does not exist. |
 | `direction`             | The metadata that defines the direction of data flow (`source` or `sink`).<br><br> This is a `source` connector.
 
 Lastly, create the connector

--- a/content/news/this-week-in-fluvio-0020.md
+++ b/content/news/this-week-in-fluvio-0020.md
@@ -242,7 +242,6 @@ Create a connector configuration file `example-connector.yaml`:
 version: dev
 name: cat-facts-connector
 type: cat-facts
-create_topic: true
 topic: cat-facts-random
 direction: source
 ```
@@ -252,7 +251,6 @@ direction: source
 | `version`               | This value must be  `dev`  for local development.                                                                                                                        |
 | `name`                  | A unique name for this connector. <br><br> It will be displayed in `fluvio connector list`                                                                                                               |
 | `type`                  | The value of this name will be used for tagging image before loading into Kubernetes. <br><br> Connector image names follow the pattern: `infinyon/fluvio-connect-{type}` |
-| `create_topic`          | Set this `true`/`false` based on whether you want a topic automatically created for your connector. (Ignored if topic already created)                                                                       |
 | `topic`                 | The name of the `topic` where the connector will publish the data records. .                                                                            |
 | `direction`             | The metadata that defines the direction of data flow (`source` or `sink`).<br><br> This is a `source` connector.
 

--- a/content/news/this-week-in-fluvio-0022.md
+++ b/content/news/this-week-in-fluvio-0022.md
@@ -24,7 +24,6 @@ version: 0.1.1
 name: my-test-connector
 type: test-connector
 topic: my-test-connector-topic
-create_topic: true 
 direction: source
 ```
 
@@ -185,7 +184,6 @@ version: 0.1.0
 name: my-postgres-source
 type: postgres-source
 topic: postgres-topic
-create_topic: true
 parameters:
   publication: fluvio
   slot: fluvio
@@ -204,7 +202,6 @@ version: 0.1.0
 name: my-postgres-sink
 type: postgres-sink
 topic: postgres-topic
-create_topic: true
 parameters:
   url: postgres://postgres:mysecretpassword@localhost:5432/postgres
 secrets:
@@ -234,7 +231,6 @@ api_version: v1
 name: cat-facts
 type: http
 topic: cat-facts
-create_topic: true
 direction: source
 parameters:
   endpoint: https://catfact.ninja/fact


### PR DESCRIPTION
Removes the deprecated create_topic (https://github.com/infinyon/fluvio/issues/2200)
Merge to stable when 0.9.20 is released