### PR TITLE
fix(connectors): align and pin versions to current

### DIFF
--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -58,7 +58,7 @@ from a JSON API.
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: cat-facts
 type: http
 topic: cat-facts
@@ -334,7 +334,7 @@ For this example, we would add `map` to the `parameters` section, like so:
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: cat-facts
 type: http
 topic: cat-facts

--- a/content/connectors/examples/github.md
+++ b/content/connectors/examples/github.md
@@ -39,7 +39,7 @@ the file:
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: github-repo
 type: http
 topic: github-repo
@@ -289,12 +289,12 @@ Since we're using a SmartModule from source, the next thing we need to do is com
 $ cargo build --release
 ```
 
-Next, we need to register this SmartModule using the `fluvio smartmodule` command, giving it a
+Next, we need to register this SmartModule using the `fluvio smart-module` command, giving it a
 name that we can use to refer to it later.
 
 %copy first-line%
 ```bash
-$ fluvio smartmodule create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
+$ fluvio smart-module create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
 ```
 
 At this point, our SmartModule has been registered and named `github-smartmodule`. Now, we can
@@ -320,7 +320,7 @@ Then, we can edit the `connect.yml` file and tell it to use our SmartModule as a
 %copy%
 {{< highlight yaml "hl_lines=12" >}}
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: github-repo
 type: http
 topic: github-repo

--- a/content/connectors/sources/http.md
+++ b/content/connectors/sources/http.md
@@ -37,7 +37,7 @@ something like this:
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: cat-facts
 type: http
 topic: cat-facts

--- a/content/connectors/sources/mqtt.md
+++ b/content/connectors/sources/mqtt.md
@@ -34,14 +34,15 @@ typically called `connect.yml`. The config file might look like the following:
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: my-mqtt
 type: mqtt
 topic: mqtt-topic
 direction: source
 parameters:
-  mqtt-url: "mqtt.hsl.fi"
-  mqtt-topic: "/hfp/v2/journey/#"
+  mqtt_topic: "/hfp/v2/journey/#"
+secrets:
+  MQTT_URL: mqtts://mqtt.hsl.fi:8883/
 ```
 
 The way we use this configuration is by passing it to the `fluvio connector` command,

--- a/content/connectors/sources/postgres.md
+++ b/content/connectors/sources/postgres.md
@@ -702,7 +702,7 @@ thing we'll do is set up the Fluvio Postgres connector, but I recommend you keep
 `psql` window open. We'll eventually want to come back to it in order to add some tables
 and data to the database and see the activity in the connector.
 
-### Launching the Fluvio Postgres connector
+### Launching the Fluvio Postgres Source connector
 
 To launch our Fluvio Postgres connector, we'll be using the `fluvio connector create` command.
 To use this, we first need to create a configuration file that describes the connector's
@@ -713,9 +713,9 @@ settings. The full set of options for the Fluvio Postgres connector can be found
 %copy%
 ```yml
 # connect.yml
-version: v1
+version: 0.1.0
 name: fluvio-postgres
-type: postgres
+type: postgres-source
 topic: postgres
 parameters:
   url: postgres://postgres:mysecretpassword@postgres-leader-service:5432

--- a/content/connectors/sources/template.md
+++ b/content/connectors/sources/template.md
@@ -31,7 +31,7 @@ Show an example configuration, such as:
 
 ```yaml
 # config.yml
-version: v1
+version: 0.1.0
 name: my-prometheus
 type: prometheus
 topic: prometheus-topic

--- a/content/news/this-week-in-fluvio-0009.md
+++ b/content/news/this-week-in-fluvio-0009.md
@@ -85,7 +85,7 @@ We create a new connector, with configurable details stored in a this example co
 %copy%
 
 ```yaml
-api_version: v1
+version: 0.1.0
 name: my-test-connector
 type: test-connector
 topic: my-test-connector

--- a/content/news/this-week-in-fluvio-0010.md
+++ b/content/news/this-week-in-fluvio-0010.md
@@ -29,16 +29,15 @@ We have a new connector for the MQTT protocol available.
 
 ```yaml
 # config.yaml
-api_version: v1
+version: 0.2.0
 name: my-test-mqtt
 type: mqtt
 topic: public-mqtt
 direction: source
 parameters:
-  mqtt-url: "broker.hivemq.com"
-  mqtt-topic: "testtopic/#"
-  fluvio-topic: "public-mqtt"
+  mqtt_topic: "testtopic/#"
 secrets:
+  MQTT_URL: "mqtts://broker.hivemq.com:8883"
   foo: bar
 ```
 

--- a/content/news/this-week-in-fluvio-0014.md
+++ b/content/news/this-week-in-fluvio-0014.md
@@ -23,15 +23,16 @@ Let's look at an example. We're going to look at a SmartConnector from the persp
 
 ```yaml
 # config.yaml
-api_version: v1
+version: 0.2.0
 name: my-test-mqtt
 type: mqtt
 topic: public-mqtt
 direction: source
 parameters:
-  mqtt-url: "broker.hivemq.com"
-  mqtt-topic: "testtopic/#"
+  mqtt_topic: "testtopic/#"
   map: "example-parse-mqtt-map"
+secrets:
+  MQTT_URL: "mqtts://broker.hivemq.com:8883
 ```
 
 In this example, we're using the `my-test-mqtt` connector we introduced in [a previous TWiF] to get a live bytestream from an MQTT broker and store it in a topic. But before we store it, we want to parse and transform the raw bytestream into our own types with a SmartModule.

--- a/content/news/this-week-in-fluvio-0022.md
+++ b/content/news/this-week-in-fluvio-0022.md
@@ -227,7 +227,7 @@ Example HTTP connector config
 %copy%
 ```yaml
 # connect.yml
-api_version: v1
+version: 0.2.0
 name: cat-facts
 type: http
 topic: cat-facts


### PR DESCRIPTION
* Aligns and pins the connector versions to current or future current 0.2.0 in case of mqtt
* Also I took the liberty to fix `fluvio smartmodule` to be `fluvio smart-module` in the github example
* Can be pushed to stable after mqtt connector 0.2.0 out