### PR TITLE
Fix units in benchmark table on landing page

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -60,9 +60,9 @@ Fluvio is written in **Rust**, a programming language designed for _code safety_
 | ----------------------- | :------: | :------: | :---------: |
 | **Latency** (Fibonacci) | 1,900 ms | 57.71 ms |  **~30x**   |
 | **Memory**              | 1,498 ms | 16.94 ms |  **~80x**   |
-| **Idle Memory**         |  162 Mb  | 0.36 Mb  |  **~450x**  |
+| **Idle Memory**         |  162 MB  | 0.36 MB  |  **~450x**  |
 | **CPU Utilization**     |   73%    |   24%    |   **~3x**   |
-| **Program Size**        |  27 Mb   |  3.7 Mb  |   **~8x**   |
+| **Program Size**        |  27 MB   |  3.7 MB  |   **~8x**   |
 
 These values are derived from a simple web server implementation and can be significantly higher in large programs with many libraries and dependencies.
 


### PR DESCRIPTION
Fix units in benchmark table on landing page.
I changed the milliseconds to Megabytes for the memory, and  Mb (Megabits) to MB (Megabytes).

Somebody should please cross check if this is right. I read the linked blog post and it *should* be ok
