### PR TITLE
Fix github stars example commands

### DIFF
--- a/content/connectors/examples/github.md
+++ b/content/connectors/examples/github.md
@@ -599,12 +599,12 @@ Since we're using a SmartModule from source, the next thing we need to do is com
 $ cargo build --release
 ```
 
-Next, we need to register this SmartModule using the `fluvio smartmodule` command, giving it a
+Next, we need to register this SmartModule using the `fluvio smart-module` command, giving it a
 name that we can use to refer to it later.
 
 %copy first-line%
 ```bash
-$ fluvio smartmodule create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
+$ fluvio smart-module create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
 ```
 
 At this point, our SmartModule has been registered and named `github-smartmodule`. Now, we can


### PR DESCRIPTION
Hi!
I was following along the tutorial and found an error:
```
➜  github-stars git:(master) ✗ fluvio smartmodule create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
Unable to find plugin 'fluvio-smartmodule'. Make sure it is installed in "/home/stefano/.fluvio/extensions".
```
There is a dash missing in the command. See pull request.
Version info & output with dash:
```
➜  github-stars git:(master) ✗ fluvio smart-module create github-smartmodule --wasm-file=target/wasm32-unknown-unknown/release/github_stars.wasm
➜  github-stars git:(master) ✗ fluvio smart-module list
 NAME                STATUS             SIZE 
 github-smartmodule  SmartModuleStatus  140785 
➜  github-stars git:(master) ✗ fluvio version  
Release Channel      : stable
Fluvio CLI           : 0.9.20
Fluvio CLI SHA256    : 01e4d42525292d6ca924ca6f34443f7533c269c974981634bcca1f676c80fad1
Fluvio Platform      : 0.9.17 (cloud)
Git Commit           : 50446a0ec086b9d87f7800f143a8f4f4f66285cd
OS Details           : Ubuntu 21.10 (kernel 5.13.0-28-generic)
=== Plugin Versions ===
Infinyon Cloud CLI (fluvio-cloud) : 0.1.6
Fluvio Runner (fluvio-run)     : 0.0.0
```