### PR TITLE
's/full_table/full-table/g'

### DIFF
--- a/content/cli/advanced/consume_table.md
+++ b/content/cli/advanced/consume_table.md
@@ -6,7 +6,7 @@ weight: 10
 
 This document covers two of the the CLI Consumer's output types.
 * [`--output table`]({{< ref "#table" >}}) which is a simple formatted table
-* [`--output full_table`]({{< ref "#full_table" >}}) which is a text-based user interface, with features such as live row-based updates, and column customization via [`table-format`]
+* [`--output full-table`]({{< ref "#full-table" >}}) which is a text-based user interface, with features such as live row-based updates, and column customization via [`table-format`]
 
 
 To demonstrate the table output, we're going to use the following input
@@ -27,9 +27,9 @@ The expected shape of the data is either:
 
 ## table
 
-By default the top-level object keys will be used as the column names, sorted by alphabetical order. For more customizability, please use the [`full_table`] output
+By default the top-level object keys will be used as the column names, sorted by alphabetical order. For more customizability, please use the [`full-table`] output
 
-[`full_table`]: {{< ref "#full_table" >}}
+[`full-table`]: {{< ref "#full-table" >}}
 
 Example command:
 
@@ -50,7 +50,7 @@ Example output:
 ```
 
 
-## full_table
+## full-table
 
 By default the top-level object keys will be used as the column names, sorted by alphabetical order.
 
@@ -58,7 +58,7 @@ Example command:
 
 %copy first-line%
 ```shell
-$ fluvio consume example-topic --output full_table -B
+$ fluvio consume example-topic --output full-table -B
 ```
 
 Example output:
@@ -82,13 +82,13 @@ You can scroll with
 * `c` to clear the table state
 * `q` or `ESC` to exit the table
 
-### Customize the `full_table` table
+### Customize the `full-table` table
 You may have json data that isn't most effectively displayed with the keys ordered alphabetically. Or your data is event sourced, and you only want to see the most recent data organized by one or more primary keys.
 
-In that case, to customize the `full_table` output, you can provide the name of your [`table-format`].
+In that case, to customize the `full-table` output, you can provide the name of your [`table-format`].
 
 [`table-format`]: {{< ref "/cli/commands/table-format.md" >}}
 
-`fluvio consume <topic-name> --output full_table --table-format <table-format name>`
+`fluvio consume <topic-name> --output full-table --table-format <table-format name>`
 
 For more information about how to use `table-format` to customize your table display (including how to rename and/or rearrange columns, or how to configure primary keys for row updating)

--- a/content/cli/commands/consume.md
+++ b/content/cli/commands/consume.md
@@ -50,7 +50,7 @@ OPTIONS:
         --end-offset <integer>               Consume records until end offset
     -b, --maxbytes <integer>                 Maximum number of bytes to be retrieved
     -O, --output <type>
-            Output [possible values: dynamic, text, binary, json, raw, table, full_table]
+            Output [possible values: dynamic, text, binary, json, raw, table, full-table]
 
         --derived-stream <derived-stream>    Name of DerivedStream
         --filter <filter>                    Path to a SmartModule filter wasm file

--- a/content/cli/commands/table-format.md
+++ b/content/cli/commands/table-format.md
@@ -3,9 +3,9 @@ title: TableFormat
 weight: 20
 ---
 
-Table Format is used to customize the behavior of the Fluvio consumer output type [`full_table`]. 
+Table Format is used to customize the behavior of the Fluvio consumer output type [`full-table`].
 
-[`full_table`]: {{< ref "#full_table" >}}
+[`full-table`]: {{< ref "#full-table" >}}
 
 With `table-format`, you can control the column labels, column ordering and control which keys are primary for displaying your live event data as row updates.
 
@@ -109,11 +109,11 @@ The expected shape of the data is either:
 
 **No table-format**
 
-Using the [`full_table`] output without using a table-format print each key into a column in alphabetical order from left to right.
+Using the [`full-table`] output without using a table-format print each key into a column in alphabetical order from left to right.
 
 %copy first-line%
 ```shell
-$ fluvio consume event-data -B --output full_table
+$ fluvio consume event-data -B --output full-table
 ```
 
 Output:
@@ -160,7 +160,7 @@ Display your table:
 
 %copy first-line%
 ```shell
-$ fluvio consume event-data -B --output full_table --table-format exampleformat1
+$ fluvio consume event-data -B --output full-table --table-format exampleformat1
 ```
 
 Output:
@@ -208,7 +208,7 @@ Display your table:
 
 %copy first-line%
 ```shell
-$ fluvio consume event-data -B --output full_table --table-format exampleformat2
+$ fluvio consume event-data -B --output full-table --table-format exampleformat2
 ```
 
 Output:
@@ -260,7 +260,7 @@ Display your table:
 
 %copy first-line%
 ```shell
-$ fluvio consume event-data -B --output full_table --table-format exampleformat3
+$ fluvio consume event-data -B --output full-table --table-format exampleformat3
 ```
 
 Output:
@@ -311,7 +311,7 @@ Display your table:
 
 %copy first-line%
 ```shell
-$ fluvio consume event-data -B --output full_table --table-format exampleformat4
+$ fluvio consume event-data -B --output full-table --table-format exampleformat4
 ```
 
 Output:

--- a/content/news/this-week-in-fluvio-0015.md
+++ b/content/news/this-week-in-fluvio-0015.md
@@ -231,9 +231,9 @@ Create the `tableformat`
 $ fluvio tableformat create --config tableformat-config.yaml
 ```
 
-Consuming from the topic using the `full_table` output, and our `tableformat`
+Consuming from the topic using the `full-table` output, and our `tableformat`
 ```shell
-$ fluvio consume request-events --output full_table --tableformat current-requests 
+$ fluvio consume request-events --output full-table --tableformat current-requests
 ```
 
 Output:

--- a/content/news/this-week-in-fluvio-0017.md
+++ b/content/news/this-week-in-fluvio-0017.md
@@ -13,7 +13,7 @@ programmable streaming platform written in Rust.
 
 ### TableFormat improvements
 
-Prior to this release, rendering events with `fluvio consume --output=full_table` required events to arrive as individual JSON objects. But now we can additionally accept a list of events as an array of JSON objects.
+Prior to this release, rendering events with `fluvio consume --output=full-table` required events to arrive as individual JSON objects. But now we can additionally accept a list of events as an array of JSON objects.
 
 Example topic data. Mix of JSON objects, and an array of objects.
 


### PR DESCRIPTION
With the change to clap in https://github.com/infinyon/fluvio/pull/2281 full_table was changed to full-table: See https://github.com/clap-rs/clap/issues/3564

This PR changes all occurrences of `full_table` with `full-table`