### PR TITLE
[Merged by Bors] - fix: Remove beta from connectors page

### DIFF
--- a/content/connectors/_index.md
+++ b/content/connectors/_index.md
@@ -5,10 +5,6 @@ section: Connectors
 toc: true
 ---
 
-{{<caution>}}
-This version of connectors is in Beta
-{{</caution>}}
-
 Smart Connectors make the process of importing or exporting data simple.
 You can import data with an `Inbound` connector and export data with an `Outbound` connector.
 


### PR DESCRIPTION
This is the only option for connectors, so we don't need the label