### PR TITLE
[Merged by Bors] - (website): correct usage of topic create

### DIFF
--- a/content/docs/architecture/replica-assignment.md
+++ b/content/docs/architecture/replica-assignment.md
@@ -209,7 +209,7 @@ The following command creates a topic from a **replica assignment file**:
 
 %copy first-line%
 ```bash
-$ fluvio topic create --topic custom-topic --replica-assignment ./my-assignment
+$ fluvio topic create custom-topic --replica-assignment ./my-assignment
 ```
 
 _Validate-only_ flag is available to verify a replica assignment file without applying any changes.

--- a/content/docs/concepts/topics.md
+++ b/content/docs/concepts/topics.md
@@ -20,7 +20,7 @@ Replicas have a leader and one or more followers and distributed across all avai
 For example, when provisioning a topic with **2** partitions and **3** replicas:
 
 ```bash
-$ fluvio topic create --topic topic-a --partitions 2 --replication 3
+$ fluvio topic create topic-a --partitions 2 --replication 3
 ```
 
 **Leaders** maintain the primary data set and **followers** store a copy of the data. Leader and follower replications are assigned to independent **SPUs**:


### PR DESCRIPTION
This PR corrects the example usages of `$ fluvio topic create`.

The `$ fluvio topic create` subcommand takes in the the topic name as a positional argument; `--topic` is not valid. Please refer to the following screenshot for more information:

<img width="1077" alt="Screen Shot 2023-10-18 at 9 42 18 PM" src="https://github.com/infinyon/fluvio-website/assets/45523555/0905952e-ac79-4a26-8aca-dd9b198562c6">
