### PR TITLE
fixup docs before fvm release

### DIFF
--- a/content/cli/advanced/cli_channels.md
+++ b/content/cli/advanced/cli_channels.md
@@ -12,7 +12,7 @@ This is currently in BETA
 
 %copy first-line%
 ```shell
-$ https://hub-dev.infinyon.cloud/install_fvm/install_fvm.sh | bash
+$ https://hub.infinyon.cloud/install_fvm/install_fvm.sh | bash
 ```
 {{</idea>}}
 
@@ -34,7 +34,7 @@ Release channel support is provided by `fvm`. The installer uses the `stable` ch
 
 %copy first-line%
 ```shell
-$ https://hub-dev.infinyon.cloud/install_fvm/install_fvm.sh | bash
+$ https://hub.infinyon.cloud/install_fvm/install_fvm.sh | bash
 ```
  
 

--- a/embeds/download-cli/curl-bash-copy.md
+++ b/embeds/download-cli/curl-bash-copy.md
@@ -9,5 +9,5 @@ Beta installation method:
 
 %copy first-line%
 ```bash
-$ curl -fsS https://hub-dev.infinyon.cloud/install_fvm/install_fvm.sh | bash
+$ curl -fsS https://hub.infinyon.cloud/install_fvm/install_fvm.sh | bash
 ```


### PR DESCRIPTION
change hub-dev to hub (hub-dev changed the fvm endpoint in prep for next release)