### PR TITLE
docs: fix link for go package

### DIFF
--- a/content/api/_index.md
+++ b/content/api/_index.md
@@ -26,7 +26,7 @@ For generated API Docs visit:
 </div>
 
 <div style="padding-left: 12px; display: inline">
-{{< icon-gopher link="https://infinyon.github.io/fluvio-client-java/com/infinyon/fluvio/package-summary.html" external="true">}}
+{{< icon-gopher link="https://www.fluvio.io/api/community/go/" external="true">}}
 </div>
 
 <div style="padding-left: 12px; display: inline">


### PR DESCRIPTION
Prefers the doc page hosted by fluvio since none is directly offered by package