### PR TITLE
docs: change `config-example.yaml` to `sample-config.yaml`

### DIFF
--- a/content/connectors/cdk/build-test.md
+++ b/content/connectors/cdk/build-test.md
@@ -27,11 +27,11 @@ If the connector builds successfully, it’s time to start an instance with `cdk
 
 The `--config <PATH>` argument is required. It is a path to the configuration file in YAML format. 
 
-Generating the project with `cdk generate` should have created a sample config for you named `config-example.yaml`
+Generating the project with `cdk generate` should have created a sample config for you named `sample-config.yaml`
 
 %copy first-line%
 ```bash
-$ cdk test --config config-example.yaml 
+$ cdk test --config sample-config.yaml 
     Finished release [optimized] target(s) in 0.16s
 Connector runs with process id: 80380
 Starting my-connector source connector with CustomConfig { foo: "bar" }

--- a/content/connectors/cdk/start-shutdown.md
+++ b/content/connectors/cdk/start-shutdown.md
@@ -16,7 +16,7 @@ When you are ready, you can run `cdk deploy start` to run your connector in the 
 
 %copy first-line%
 ```bash
-$ cdk deploy start --config config-example.yaml 
+$ cdk deploy start --config sample-config.yaml 
 Log file: /private/tmp/my-connector/my-connector.log
 Connector runs with process id: 88589
 ```
@@ -28,7 +28,7 @@ Example:
 
 %copy first-line%
 ```bash
-$ cdk deploy start --ipkg infinyon-http-source-0.1.1.ipkg --config config-example.yaml
+$ cdk deploy start --ipkg infinyon-http-source-0.1.1.ipkg --config sample-config.yaml
 ```
 {{</idea>}}
 
@@ -40,7 +40,7 @@ In order to use [secrets]({{<ref "/connectors/secrets">}}), you can use the `--s
 
 %copy first-line%
 ```bash
-$ cdk deploy start --config config-example.yaml --secrets secrets.txt
+$ cdk deploy start --config sample-config.yaml --secrets secrets.txt
 ```
 
 In the secrets file, you should define a secret per line in the format `SECRET_NAME=SECRET_VALUE`.

--- a/embeds/cdk/tree-output.md
+++ b/embeds/cdk/tree-output.md
@@ -3,7 +3,7 @@ $ tree
 .
 ├── Cargo.toml
 ├── Connector.toml
-├── config-example.yaml
+├── sample-config.yaml
 └── src
     ├── config.rs
     └── main.rs

--- a/embeds/cli/example/cdk-generate-example.md
+++ b/embeds/cli/example/cdk-generate-example.md
@@ -11,7 +11,7 @@ $ cdk generate
 Ignoring: /var/folders/r8/4x6_d2rn283946frzd1gc1pr0000gn/T/.tmptToFV3/cargo-generate.toml
 [1/6]   Done: Cargo.toml             
 [2/6]   Done: Connector.toml
-[3/6]   Done: config-example.yaml
+[3/6]   Done: sample-config.yaml
 [4/6]   Done: src/config.rs
 [5/6]   Done: src/main.rs
 [6/6]   Done: src

--- a/embeds/connectors/inbound/http.md
+++ b/embeds/connectors/inbound/http.md
@@ -33,7 +33,7 @@ Tutorial for [HTTP to SQL Pipeline](https://www.fluvio.io/docs/tutorials/data-pi
 This is an example of simple connector config file:
 
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5
@@ -63,7 +63,7 @@ The produced record in Fluvio topic will be:
 Fluvio HTTP Source Connector supports Secrets in the `endpoint` and in the `headers` parameters:
 
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5
@@ -89,7 +89,7 @@ Fluvio HTTP Source Connector supports [Transformations](https://www.fluvio.io/do
 
 The previous example can be extended to add extra transformations to outgoing records:
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5

--- a/embeds/connectors/inbound/kafka.md
+++ b/embeds/connectors/inbound/kafka.md
@@ -32,7 +32,7 @@ To try out Kafka Source connector locally, you can use Fluvio CDK tool:
 ```bash
 fluvio install cdk
 
-cdk deploy -p kafka-source start --config crates/kafka-source/config-example.yaml
+cdk deploy -p kafka-source start --config crates/kafka-source/sample-config.yaml
 ```
 
 ## Transformations

--- a/embeds/connectors/inbound/mqtt.md
+++ b/embeds/connectors/inbound/mqtt.md
@@ -47,7 +47,7 @@ JSON Serialized string with fields `mqtt_topic` and `payload`
 This is an example of connector config file:
 
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5
@@ -68,7 +68,7 @@ Run connector locally using `cdk` tool (from root directory or any sub-directory
 ```bash
 fluvio install cdk
 
-cdk deploy start --config config-example.yaml
+cdk deploy start --config sample-config.yaml
 
 cdk deploy list # to see the status
 cdk deploy log my-mqtt-connector # to see connector's logs
@@ -102,7 +102,7 @@ Fluvio MQTT Source Connector supports [Transformations](https://www.fluvio.io/do
 
 The previous example can be extended to add extra transformations to outgoing records:
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5

--- a/embeds/connectors/outbound/http.md
+++ b/embeds/connectors/outbound/http.md
@@ -13,7 +13,7 @@ HTTP sink connector reads records from data streaming and generates an HTTP requ
 HTTP Sink is configured using a YAML file:
 
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5
@@ -130,7 +130,7 @@ Fluvio HTTP Sink Connector supports [Transformations](https://www.fluvio.io/docs
 
 The previous example can be extended to add extra transformations to outgoing records:
 ```yaml
-# config-example.yaml
+# sample-config.yaml
 apiVersion: 0.1.0
 meta:
   version: 0.2.5

--- a/embeds/connectors/outbound/kafka.md
+++ b/embeds/connectors/outbound/kafka.md
@@ -71,7 +71,7 @@ To try out Kafka Sink connector locally, you can use Fluvio CDK tool:
 ```bash
 fluvio install cdk
 
-cdk deploy -p kafka-sink start --config crates/kafka-sink/config-example.yaml
+cdk deploy -p kafka-sink start --config crates/kafka-sink/sample-config.yaml
 ```
 
 ### Testing with security


### PR DESCRIPTION
that's the name of the file generated by `cdk generate`

```
❯ ls -l
total 108
-rw-r--r-- 1 m m 86529 Dec 21 23:05 Cargo.lock
-rw-r--r-- 1 m m   445 Dec 21 23:03 Cargo.toml
-rw-r--r-- 1 m m   287 Dec 21 23:03 Connector.toml
-rw-r--r-- 1 m m    24 Dec 21 23:03 .gitignore
-rw-r--r-- 1 m m     6 Dec 21 23:03 README.md
-rw-r--r-- 1 m m   133 Dec 21 23:03 sample-config.yaml
drwxr-xr-x 1 m m    32 Dec 21 23:03 src
drwxr-xr-x 1 m m   120 Dec 21 23:05 target
```

i blindly renamed every occurrence, don't approve without careful review, as i havent made myself familiar with all docs yet


```
❯ fluvio version
Fluvio CLI           : 0.11.2
Fluvio CLI Arch      : x86_64-unknown-linux-musl
Fluvio CLI SHA256    : ad780eb2573279ad625ddc373fea8701a3d3478763e1af99d365c5903ef24006
Fluvio channel frontend SHA256 : ad780eb2573279ad625ddc373fea8701a3d3478763e1af99d365c5903ef24006
Fluvio Platform      : 0.11.2 (default)
Git Commit           : cddc05388b7a1278837adc506430f339f311212d
OS Details           : Arch Linux rolling (kernel 6.6.7-zen1-1-zen)
=== Plugin Versions ===


❯ cdk version
CDK CLI: 0.11.2
CDK CLI Arch: x86_64-unknown-linux-musl
CDK CLI SHA256: caaa28e6f577fd67a2ea8ac8b22351c9ece84f680ce2621523ced4bfb02fefdd
OS Details: Arch Linux rolling (kernel 6.6.7-zen1-1-zen)
```