### PR TITLE
Clarified the term SPU and linked to appropriate page

### DIFF
--- a/content/docs/concepts/topics.md
+++ b/content/docs/concepts/topics.md
@@ -11,7 +11,9 @@ with parameters to tune the performance and semantics of record delivery.
 
 Topics also have a **replication factor** that defines durability, the number of copies for each data slice.
 
--> **Note**: Replication factor must be less or equal to the number of SPUs.  While topics that exceed the number of available SPUs may be created, they are not provisioned until additional SPUs join the cluster.
+-> **Note**: Replication factor must be less or equal to the number of SPUs ([Stream Processing Units]).  While topics that exceed the number of available SPUs may be created, they are not provisioned until additional SPUs join the cluster.
+
+[Stream Processing Units]: {{< ref "docs/architecture/spu">}}
 
 Replicas have a leader and one or more followers and distributed across all available SPUs according to the [replica assignment algorithm].
 


### PR DESCRIPTION
I thought it might be useful to others to have "SPU" spelled out the first time it's mentioned, with a link to the SPU page in the Architecture section. This could trip people up if they're going through the docs in order, since SPU isn't explained until a later section.