### PR TITLE
chore: fix lint ci

### DIFF
--- a/.github/workflows/htmltest.yml
+++ b/.github/workflows/htmltest.yml
@@ -10,7 +10,9 @@ concurrency:
 on:
   merge_group:
   pull_request:
-    branches: [master]
+    branches:
+    - master
+    - stable
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
merge to stable blocked because lint does not run on pr