### PR TITLE
fix: fish script missing .fvm/ dir

### DIFF
--- a/content/docs/install.md
+++ b/content/docs/install.md
@@ -32,7 +32,7 @@ $ echo 'export PATH="${HOME}/.fvm/bin:${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
 {{< h-item tabNum="3">}}
 %copy first-line%
 ```shell
-$ fish_add_path ~/.fluvio/bin
+$ fish_add_path ~/.fluvio/bin ~/.fvm/bin
 ```
 {{< /h-item>}}
 


### PR DESCRIPTION
modify fish script to include ~/.fvm/bin directory